### PR TITLE
fix: make source-ref installs self-contained

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"ci:test:full": "bun run test",
 		"ci:test:smoke": "bun packages/coding-agent/src/cli.ts --version && bun packages/coding-agent/src/cli.ts --help && bun packages/coding-agent/src/cli.ts stats --help && bun packages/coding-agent/src/cli.ts validate --help",
 		"ci:test:install-methods": "bash scripts/install-tests/run-ci.sh",
+		"uat:openai-subscription": "bun packages/coding-agent/scripts/openai-subscription-uat.ts",
 		"ci:release:verify-natives": "bun scripts/ci-release-verify-natives.ts",
 		"ci:release:verify-native-signing": "bun scripts/ci-release-verify-native-signing.ts",
 		"ci:release:build-binaries": "bun scripts/ci-release-build-binaries.ts",

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -906,35 +906,35 @@ const response = await complete(
 
 In Node.js environments, you can set environment variables to avoid passing API keys:
 
-| Provider       | Environment Variable(s)                                                      |
-| -------------- | ---------------------------------------------------------------------------- |
-| OpenAI         | `OPENAI_API_KEY`                                                             |
-| Anthropic      | `ANTHROPIC_API_KEY` or `ANTHROPIC_OAUTH_TOKEN` (or `ANTHROPIC_FOUNDRY_API_KEY` when `CLAUDE_CODE_USE_FOUNDRY=true`) |
-| Google         | `GEMINI_API_KEY`                                                             |
-| Vertex AI      | `GOOGLE_CLOUD_PROJECT` (or `GCLOUD_PROJECT`) + `GOOGLE_CLOUD_LOCATION` + ADC |
-| Mistral        | `MISTRAL_API_KEY`                                                            |
-| Groq           | `GROQ_API_KEY`                                                               |
-| Cerebras       | `CEREBRAS_API_KEY`                                                           |
-| Together       | `TOGETHER_API_KEY`                                                           |
-| Qianfan        | `QIANFAN_API_KEY`                                                            |
-| Hugging Face   | `HUGGINGFACE_HUB_TOKEN` or `HF_TOKEN`                                        |
-| Synthetic      | `SYNTHETIC_API_KEY`                                                          |
-| NVIDIA         | `NVIDIA_API_KEY`                                                             |
-| NanoGPT        | `NANO_GPT_API_KEY`                                                          |
-| Venice         | `VENICE_API_KEY`                                                             |
-| Moonshot       | `MOONSHOT_API_KEY`                                                           |
-| xAI            | `XAI_API_KEY`                                                                |
-| OpenRouter     | `OPENROUTER_API_KEY`                                                         |
-| LiteLLM        | `LITELLM_API_KEY`                                                            |
-| Ollama         | `OLLAMA_API_KEY` (optional for local deployments)                            |
-| Qwen Portal    | `QWEN_OAUTH_TOKEN` or `QWEN_PORTAL_API_KEY`                                  |
-| zAI            | `ZAI_API_KEY`                                                                |
-| MiniMax Code   | `MINIMAX_CODE_API_KEY` (international) or `MINIMAX_CODE_CN_API_KEY` (China) |
-| Xiaomi MiMo    | `XIAOMI_API_KEY`                                                             |
-| ZenMux         | `ZENMUX_API_KEY`                                                             |
-| vLLM           | `VLLM_API_KEY`                                                               |
-| Cloudflare AI Gateway | `CLOUDFLARE_AI_GATEWAY_API_KEY`                                      |
-| GitHub Copilot | `COPILOT_GITHUB_TOKEN` or `GH_TOKEN` or `GITHUB_TOKEN`                      |
+| Provider              | Environment Variable(s)                                                                                             |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| OpenAI                | `OPENAI_API_KEY`                                                                                                    |
+| Anthropic             | `ANTHROPIC_API_KEY` or `ANTHROPIC_OAUTH_TOKEN` (or `ANTHROPIC_FOUNDRY_API_KEY` when `CLAUDE_CODE_USE_FOUNDRY=true`) |
+| Google                | `GEMINI_API_KEY`                                                                                                    |
+| Vertex AI             | `GOOGLE_CLOUD_PROJECT` (or `GCLOUD_PROJECT`) + `GOOGLE_CLOUD_LOCATION` + ADC                                        |
+| Mistral               | `MISTRAL_API_KEY`                                                                                                   |
+| Groq                  | `GROQ_API_KEY`                                                                                                      |
+| Cerebras              | `CEREBRAS_API_KEY`                                                                                                  |
+| Together              | `TOGETHER_API_KEY`                                                                                                  |
+| Qianfan               | `QIANFAN_API_KEY`                                                                                                   |
+| Hugging Face          | `HUGGINGFACE_HUB_TOKEN` or `HF_TOKEN`                                                                               |
+| Synthetic             | `SYNTHETIC_API_KEY`                                                                                                 |
+| NVIDIA                | `NVIDIA_API_KEY`                                                                                                    |
+| NanoGPT               | `NANO_GPT_API_KEY`                                                                                                  |
+| Venice                | `VENICE_API_KEY`                                                                                                    |
+| Moonshot              | `MOONSHOT_API_KEY`                                                                                                  |
+| xAI                   | `XAI_API_KEY`                                                                                                       |
+| OpenRouter            | `OPENROUTER_API_KEY`                                                                                                |
+| LiteLLM               | `LITELLM_API_KEY`                                                                                                   |
+| Ollama                | `OLLAMA_API_KEY` (optional for local deployments)                                                                   |
+| Qwen Portal           | `QWEN_OAUTH_TOKEN` or `QWEN_PORTAL_API_KEY`                                                                         |
+| zAI                   | `ZAI_API_KEY`                                                                                                       |
+| MiniMax Code          | `MINIMAX_CODE_API_KEY` (international) or `MINIMAX_CODE_CN_API_KEY` (China)                                         |
+| Xiaomi MiMo           | `XIAOMI_API_KEY`                                                                                                    |
+| ZenMux                | `ZENMUX_API_KEY`                                                                                                    |
+| vLLM                  | `VLLM_API_KEY`                                                                                                      |
+| Cloudflare AI Gateway | `CLOUDFLARE_AI_GATEWAY_API_KEY`                                                                                     |
+| GitHub Copilot        | `COPILOT_GITHUB_TOKEN` or `GH_TOKEN` or `GITHUB_TOKEN`                                                              |
 
 For Cloudflare AI Gateway models, use provider base URL format
 `https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/anthropic`.

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -46,8 +46,7 @@ Unified LLM API with automatic model discovery, provider configuration, token an
 
 ## Supported Providers
 
-- **OpenAI**
-- **OpenAI Codex** (ChatGPT Plus/Pro subscription, requires OAuth, see below)
+- **OpenAI** (usage-based Platform API access)
 - **Anthropic**
 - **Google**
 - **Vertex AI** (Gemini via Vertex AI)
@@ -988,7 +987,6 @@ const key = getEnvApiKey("openai"); // checks OPENAI_API_KEY
 Several providers support OAuth authentication (some also support static API keys):
 
 - **Anthropic** (Claude Pro/Max subscription)
-- **OpenAI Codex** (ChatGPT Plus/Pro subscription, access to GPT-5.x Codex models)
 - **GitHub Copilot** (Copilot subscription)
 - **Google Gemini CLI** (Gemini 2.0/2.5 via Google Cloud Code Assist; free tier or paid subscription)
 - **Antigravity** (Free Gemini 3, Claude, GPT-OSS via Google Cloud)
@@ -1047,7 +1045,8 @@ bunx @f5-sales-demo/pi-ai list               # list available providers
 
 Credentials are saved to `agent.db` in the agent directory. `/login qianfan` opens the Qianfan console and stores the pasted API key.
 
-`login` supports OAuth providers (Anthropic, OpenAI Codex, GitHub Copilot, Gemini CLI, Antigravity) and API-key onboarding flows.
+`login` supports OAuth providers (Anthropic, GitHub Copilot, Gemini CLI, Antigravity) and API-key onboarding flows.
+OpenAI uses usage-based Platform API access through `OPENAI_API_KEY`. For ChatGPT subscription access, use the official Codex CLI and run `codex login`.
 
 For the current OpenAI-compatible integrations, API-key onboarding covers Together, Moonshot, Qianfan, NVIDIA, NanoGPT, Hugging Face, Venice, Xiaomi, vLLM, LiteLLM, Cloudflare AI Gateway, and Qwen Portal. Ollama is typically local and unauthenticated; set `OLLAMA_API_KEY` only when your Ollama deployment enforces bearer auth.
 
@@ -1059,7 +1058,6 @@ The library provides login and token refresh functions. Credential storage is th
 import {
  // Login functions (return credentials, do not store)
  loginAnthropic,
- loginOpenAICodex,
  loginGitHubCopilot,
  loginGeminiCli,
  loginAntigravity,
@@ -1081,18 +1079,9 @@ import {
  getOAuthApiKey, // (provider, credentialsMap) => { newCredentials, apiKey } | null
 
  // Types
- type OAuthProvider, // includes 'anthropic', 'openai-codex', 'github-copilot', 'google-gemini-cli', 'google-antigravity', 'together', 'moonshot', 'qianfan', 'nvidia', 'nanogpt', 'huggingface', 'venice', 'xiaomi', 'vllm', 'litellm', 'cloudflare-ai-gateway', 'qwen-portal', ...
+ type OAuthProvider,
  type OAuthCredentials,
 } from "@f5-sales-demo/pi-ai";
-```
-
-`loginOpenAICodex` accepts an optional `originator` value used in the OAuth flow:
-
-```typescript
-await loginOpenAICodex({
- onAuth: ({ url }) => console.log(url),
- originator: "my-cli",
-});
 ```
 
 ### Login Flow Example
@@ -1149,7 +1138,7 @@ const response = await complete(
 
 ### Provider Notes
 
-**OpenAI Codex**: Requires a ChatGPT Plus or Pro subscription. Provides access to GPT-5.x Codex models with extended context windows and reasoning capabilities. The library automatically handles session-based prompt caching when `sessionId` is provided in stream options.
+**OpenAI**: Set `OPENAI_API_KEY` for usage-based Platform API access. ChatGPT subscription access is available through the official Codex CLI, not this library.
 
 **GitHub Copilot**: If you get "The requested model is not supported" error, enable the model manually in VS Code: open Copilot Chat, click the model selector, select the model (warning icon), and click "Enable".
 

--- a/packages/ai/test/openai-codex-oauth-removal.test.ts
+++ b/packages/ai/test/openai-codex-oauth-removal.test.ts
@@ -57,9 +57,30 @@ describe("unsupported OpenAI Codex OAuth removal", () => {
 			files.filter(file => file.endsWith(".ts")).map(file => fs.readFile(path.join(oauthDirectory, file), "utf8")),
 		);
 		const combined = source.join("\n");
-		expect(combined).not.toContain("auth.openai.com/oauth");
+		expect(combined).not.toContain("auth.openai.com");
 		expect(combined).not.toContain("originator");
 		expect(combined).not.toContain("app_EMoamEEZ73f0CkXaXp7hrann");
+	});
+
+	test("does not advertise the removed ChatGPT OAuth integration in package documentation", async () => {
+		const readme = await fs.readFile(path.resolve(import.meta.dir, "../README.md"), "utf8");
+		expect(readme).not.toMatch(/ChatGPT (?:Plus|Pro)/i);
+		expect(readme).not.toContain("loginOpenAICodex");
+		expect(readme).not.toContain("originator");
+	});
+
+	test("keeps live subscription acceptance behind the official credential-owning Codex CLI", async () => {
+		const uat = await fs.readFile(
+			path.resolve(import.meta.dir, "../../coding-agent/scripts/openai-subscription-uat.ts"),
+			"utf8",
+		);
+		expect(uat).toContain("PtySession");
+		expect(uat).toContain('["login", "status"]');
+		expect(uat).toContain('"gpt-5.6"');
+		expect(uat).toContain('"read-only"');
+		expect(uat).toContain('"--ephemeral"');
+		expect(uat).not.toContain("auth.json");
+		expect(uat).not.toContain("CODEX_HOME");
 	});
 
 	test("discovers an OpenAI API key and selects the standard Responses provider", async () => {

--- a/packages/coding-agent/scripts/openai-subscription-uat.ts
+++ b/packages/coding-agent/scripts/openai-subscription-uat.ts
@@ -1,0 +1,286 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { PtySession } from "@f5-sales-demo/pi-natives";
+
+interface UatTarget {
+	label: string;
+	command: string;
+	executable?: string;
+}
+
+interface CommandResult {
+	exitCode: number;
+	stdout: string;
+	stderr: string;
+}
+
+const ROOT_DIR = path.resolve(import.meta.dir, "../../..");
+const PTY_TIMEOUT_MS = 60_000;
+const CODEX_TIMEOUT_MS = 180_000;
+
+function shellQuote(value: string): string {
+	return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+function parseTargets(argv: string[]): UatTarget[] {
+	const targets: UatTarget[] = [];
+	for (let index = 0; index < argv.length; index += 1) {
+		const argument = argv[index];
+		if (argument === "--source") {
+			targets.push({
+				label: "Bun development xcsh",
+				command: [
+					"bun",
+					"packages/coding-agent/src/cli.ts",
+					"--no-session",
+					"--no-mcp",
+					"--model",
+					"openai/gpt-5-mini",
+				]
+					.map(shellQuote)
+					.join(" "),
+			});
+			continue;
+		}
+		if (argument === "--installed") {
+			const executable = argv[index + 1];
+			if (!executable) throw new Error("--installed requires the path to an xcsh executable");
+			index += 1;
+			targets.push({
+				label: `Installed xcsh (${executable})`,
+				command: [executable, "--no-session", "--no-mcp", "--model", "openai/gpt-5-mini"].map(shellQuote).join(" "),
+				executable,
+			});
+			continue;
+		}
+		throw new Error(`Unknown argument: ${argument}`);
+	}
+	if (targets.length === 0) {
+		return parseTargets(["--source"]);
+	}
+	return targets;
+}
+
+function visibleTranscript(value: string): string {
+	return Bun.stripANSI(value)
+		.replaceAll("\r", "\n")
+		.replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, "");
+}
+
+async function waitForText(
+	label: string,
+	getTranscript: () => string,
+	text: string,
+	hasExited: () => boolean,
+): Promise<void> {
+	const deadline = Date.now() + PTY_TIMEOUT_MS;
+	while (Date.now() < deadline) {
+		const transcript = visibleTranscript(getTranscript());
+		if (transcript.includes(text)) return;
+		if (hasExited()) {
+			throw new Error(`${label} exited before rendering ${JSON.stringify(text)}\n${transcript.slice(-4000)}`);
+		}
+		await Bun.sleep(50);
+	}
+	throw new Error(
+		`${label} timed out waiting for ${JSON.stringify(text)}\n${visibleTranscript(getTranscript()).slice(-4000)}`,
+	);
+}
+
+function assertOAuthBoundary(label: string, transcript: string): void {
+	const visible = visibleTranscript(transcript);
+	const required = [
+		"OpenAI Responses API (usage-based API access)",
+		"OpenAI Responses API uses usage-based Platform API access.",
+		"Set OPENAI_API_KEY, then select an OpenAI model with /model.",
+		"For ChatGPT subscription access, use the official codex CLI (`codex login`).",
+	];
+	for (const expected of required) {
+		if (!visible.includes(expected)) {
+			throw new Error(`${label} did not render required guidance: ${expected}`);
+		}
+	}
+
+	const forbidden: Array<[string, RegExp]> = [
+		["removed provider ID", /openai-codex/i],
+		["ChatGPT plan advertising", /ChatGPT\s+(?:Plus|Pro)\b/i],
+		["unsupported OpenAI OAuth host", /auth\.openai\.com/i],
+		["copied OpenAI OAuth client settings", /app_EMoamEEZ73f0CkXaXp7hrann/i],
+		["OpenAI OAuth originator field", /\boriginator\b/i],
+	];
+	for (const [description, pattern] of forbidden) {
+		if (pattern.test(visible)) throw new Error(`${label} exposed ${description}`);
+	}
+}
+
+async function runPtyBoundary(target: UatTarget): Promise<void> {
+	const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "xcsh-openai-boundary-"));
+	const session = new PtySession();
+	let transcript = "";
+	let callbackError: Error | undefined;
+	let exited = false;
+	const runPromise = session
+		.start(
+			{
+				command: target.command,
+				cwd: ROOT_DIR,
+				env: {
+					HOME: stateDir,
+					PI_CODING_AGENT_DIR: path.join(stateDir, "agent"),
+					XDG_CACHE_HOME: path.join(stateDir, "cache"),
+					XDG_CONFIG_HOME: path.join(stateDir, "config"),
+					XDG_DATA_HOME: path.join(stateDir, "data"),
+					XDG_STATE_HOME: path.join(stateDir, "state"),
+					OPENAI_API_KEY: "sk-xcsh-boundary-uat-not-a-real-key",
+					TERM: "xterm-256color",
+				},
+				cols: 120,
+				rows: 40,
+				timeoutMs: PTY_TIMEOUT_MS,
+			},
+			(error, chunk) => {
+				if (error) callbackError = error;
+				if (chunk) transcript += chunk;
+			},
+		)
+		.finally(() => {
+			exited = true;
+		});
+
+	try {
+		await waitForText(
+			target.label,
+			() => transcript,
+			"xcsh v",
+			() => exited,
+		);
+		// The welcome frame can render before the editor focus and input handlers are attached.
+		await Bun.sleep(1000);
+		session.write("/login\r");
+		await waitForText(
+			target.label,
+			() => transcript,
+			"Type to filter providers",
+			() => exited,
+		);
+		session.write("responses api");
+		await waitForText(
+			target.label,
+			() => transcript,
+			"OpenAI Responses API (usage-based API access)",
+			() => exited,
+		);
+		session.write("\r");
+		await waitForText(
+			target.label,
+			() => transcript,
+			"For ChatGPT subscription access, use the official codex CLI (`codex login`).",
+			() => exited,
+		);
+		if (callbackError) throw callbackError;
+		assertOAuthBoundary(target.label, transcript);
+		console.log(`PASS: ${target.label} kept OpenAI subscription authentication at the official Codex boundary.`);
+	} finally {
+		if (!exited) session.kill();
+		await runPromise.catch(() => undefined);
+		await fs.rm(stateDir, { recursive: true, force: true });
+	}
+}
+
+async function runCommand(
+	command: string,
+	args: string[],
+	cwd: string,
+	timeoutMs: number,
+	stdinText?: string,
+): Promise<CommandResult> {
+	const process = Bun.spawn([command, ...args], {
+		cwd,
+		env: Bun.env,
+		stdin: stdinText === undefined ? "ignore" : "pipe",
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	if (stdinText !== undefined) {
+		const stdin = process.stdin;
+		if (!stdin) throw new Error(`Failed to open stdin for ${command}`);
+		stdin.write(stdinText);
+		stdin.end();
+	}
+	const stdoutPromise = new Response(process.stdout).text();
+	const stderrPromise = new Response(process.stderr).text();
+	let timedOut = false;
+	const timeout = setTimeout(() => {
+		timedOut = true;
+		process.kill();
+	}, timeoutMs);
+	const exitCode = await process.exited;
+	clearTimeout(timeout);
+	const [stdout, stderr] = await Promise.all([stdoutPromise, stderrPromise]);
+	if (timedOut) throw new Error(`${command} ${args[0] ?? ""} timed out after ${timeoutMs}ms`);
+	return { exitCode, stdout, stderr };
+}
+
+async function verifyOfficialCodexSubscription(): Promise<void> {
+	const status = await runCommand("codex", ["login", "status"], ROOT_DIR, 30_000);
+	const statusOutput = `${status.stdout}\n${status.stderr}`.trim();
+	if (status.exitCode !== 0 || !/Logged in using ChatGPT/i.test(statusOutput)) {
+		throw new Error(`Official Codex CLI is not authenticated with ChatGPT: ${statusOutput}`);
+	}
+	console.log("PASS: codex login status reports ChatGPT authentication.");
+
+	const sentinel = `XCSH_CODEX_UAT_${crypto.randomUUID().replaceAll("-", "").slice(0, 16).toUpperCase()}`;
+	const runDir = await fs.mkdtemp(path.join(os.tmpdir(), "xcsh-codex-sentinel-"));
+	try {
+		const result = await runCommand(
+			"codex",
+			[
+				"exec",
+				"--model",
+				"gpt-5.6",
+				"--sandbox",
+				"read-only",
+				"--ephemeral",
+				"--ignore-rules",
+				"--skip-git-repo-check",
+				"--json",
+			],
+			runDir,
+			CODEX_TIMEOUT_MS,
+			`Do not use tools. Reply with exactly ${sentinel} and nothing else.\n`,
+		);
+		if (result.exitCode !== 0) {
+			throw new Error(
+				`codex exec failed with exit ${result.exitCode}: ${result.stderr.trim()}\n${result.stdout.trim()}`,
+			);
+		}
+		const agentMessages: string[] = [];
+		for (const line of result.stdout.split("\n").filter(Boolean)) {
+			const event = JSON.parse(line) as { type?: string; item?: { type?: string; text?: string } };
+			if (event.type === "item.completed" && event.item?.type === "agent_message" && event.item.text) {
+				agentMessages.push(event.item.text);
+			}
+		}
+		if (agentMessages.at(-1)?.trim() !== sentinel) {
+			throw new Error(
+				`codex exec did not return the exact sentinel; received ${JSON.stringify(agentMessages.at(-1))}`,
+			);
+		}
+		console.log(`PASS: ephemeral read-only codex exec --model gpt-5.6 returned ${sentinel}.`);
+	} finally {
+		await fs.rm(runDir, { recursive: true, force: true });
+	}
+}
+
+async function main(): Promise<void> {
+	const targets = parseTargets(process.argv.slice(2));
+	for (const target of targets) {
+		if (target.executable) await fs.access(target.executable, fs.constants.X_OK);
+		await runPtyBoundary(target);
+	}
+	await verifyOfficialCodexSubscription();
+	console.log("PASS: OpenAI subscription acceptance completed without reading or injecting Codex credentials.");
+}
+
+await main();

--- a/scripts/install-tests/run-ci.sh
+++ b/scripts/install-tests/run-ci.sh
@@ -13,12 +13,12 @@ section() {
 }
 
 smoke_cli() {
-  local omp_bin="$1"
-  "$omp_bin" --version
-  "$omp_bin" --help >/dev/null
-  "$omp_bin" stats --summary >/dev/null
-  "$omp_bin" sandbox check >/dev/null
-  XCSH_SMOKE_TEST_SPECS=1 "$omp_bin" >/dev/null
+  local xcsh_bin="$1"
+  "$xcsh_bin" --version
+  "$xcsh_bin" --help >/dev/null
+  "$xcsh_bin" stats --summary >/dev/null
+  "$xcsh_bin" sandbox check >/dev/null
+  XCSH_SMOKE_TEST_SPECS=1 "$xcsh_bin" >/dev/null
 }
 
 find_tarball() {
@@ -35,6 +35,9 @@ find_tarball() {
 
   echo "${matches[0]}"
 }
+
+section "Source install smoke"
+bash scripts/install-tests/source-ref.sh
 
 section "Binary install smoke"
 bun --cwd=packages/natives run build
@@ -53,15 +56,6 @@ fi
 cp "${native_addons[@]}" "$BINARY_DIR/"
 
 smoke_cli "$BINARY_DIR/xcsh"
-
-section "Source install smoke"
-SOURCE_BUN_HOME="$WORK_DIR/bun-source"
-(
-  export BUN_INSTALL="$SOURCE_BUN_HOME"
-  export PATH="$BUN_INSTALL/bin:$PATH"
-  bun --cwd="$ROOT_DIR/packages/coding-agent" link
-  smoke_cli "$BUN_INSTALL/bin/xcsh"
-)
 
 section "Tarball install smoke"
 TARBALL_DIR="$WORK_DIR/tarballs"

--- a/scripts/install-tests/run-ci.sh
+++ b/scripts/install-tests/run-ci.sh
@@ -17,7 +17,7 @@ smoke_cli() {
   "$xcsh_bin" --version
   "$xcsh_bin" --help >/dev/null
   "$xcsh_bin" stats --summary >/dev/null
-  "$xcsh_bin" sandbox check >/dev/null
+  "$xcsh_bin" sandbox check
   XCSH_SMOKE_TEST_SPECS=1 "$xcsh_bin" >/dev/null
 }
 
@@ -36,9 +36,6 @@ find_tarball() {
   echo "${matches[0]}"
 }
 
-section "Source install smoke"
-bash scripts/install-tests/source-ref.sh
-
 section "Binary install smoke"
 bun --cwd=packages/natives run build
 bun --cwd=packages/coding-agent run build
@@ -56,6 +53,9 @@ fi
 cp "${native_addons[@]}" "$BINARY_DIR/"
 
 smoke_cli "$BINARY_DIR/xcsh"
+
+section "Source install smoke"
+bash scripts/install-tests/source-ref.sh
 
 section "Tarball install smoke"
 TARBALL_DIR="$WORK_DIR/tarballs"

--- a/scripts/install-tests/source-ref.sh
+++ b/scripts/install-tests/source-ref.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+ROOT_DIR="$(pwd)"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+SOURCE_REPO="$WORK_DIR/source-repo"
+SOURCE_INSTALL_DIR="$WORK_DIR/source-bin"
+SMOKE_HOME="$WORK_DIR/home"
+git clone --local --no-hardlinks "$ROOT_DIR" "$SOURCE_REPO" >/dev/null
+git -C "$SOURCE_REPO" config user.name "xcsh installer test"
+git -C "$SOURCE_REPO" config user.email "xcsh-installer-test@example.com"
+git -C "$SOURCE_REPO" commit --allow-empty -m "test: local source installer fixture" >/dev/null
+SOURCE_REF="$(git -C "$SOURCE_REPO" rev-parse HEAD)"
+
+PI_INSTALL_DIR="$SOURCE_INSTALL_DIR" \
+  XCSH_SOURCE_REPO_URL="$SOURCE_REPO" \
+  bash "$ROOT_DIR/scripts/install.sh" --source --ref "$SOURCE_REF"
+
+rm -rf "$SOURCE_REPO"
+mkdir -p "$SMOKE_HOME"
+
+HOME="$SMOKE_HOME" PI_CODING_AGENT_DIR="$SMOKE_HOME/agent" "$SOURCE_INSTALL_DIR/xcsh" --version
+HOME="$SMOKE_HOME" PI_CODING_AGENT_DIR="$SMOKE_HOME/agent" "$SOURCE_INSTALL_DIR/xcsh" --help >/dev/null
+HOME="$SMOKE_HOME" PI_CODING_AGENT_DIR="$SMOKE_HOME/agent" XCSH_SMOKE_TEST_SPECS=1 \
+  "$SOURCE_INSTALL_DIR/xcsh" >/dev/null
+
+if find "$SOURCE_INSTALL_DIR" -type l -print -quit | grep -q .; then
+  echo "Source install must not contain symlinks into the temporary clone"
+  exit 1
+fi
+
+case "$(uname -m)" in
+x86_64 | amd64) expected_files=3 ;;
+arm64 | aarch64) expected_files=2 ;;
+*)
+  echo "Unsupported source installer test architecture: $(uname -m)"
+  exit 1
+  ;;
+esac
+installed_files=$(find "$SOURCE_INSTALL_DIR" -maxdepth 1 -type f | wc -l)
+if [ "$installed_files" -ne "$expected_files" ]; then
+  echo "Expected ${expected_files} installed files, found ${installed_files}"
+  find "$SOURCE_INSTALL_DIR" -maxdepth 1 -type f -print
+  exit 1
+fi
+
+echo "Source-ref installer regression passed at ${SOURCE_REF}"

--- a/scripts/install-tests/source.dockerfile
+++ b/scripts/install-tests/source.dockerfile
@@ -1,24 +1,25 @@
 # Test --source install from local repo
 FROM debian:bookworm-slim
 
-RUN apt-get update && apt-get install -y curl ca-certificates unzip build-essential && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y curl ca-certificates unzip build-essential git && rm -rf /var/lib/apt/lists/*
 
 # Install bun
 RUN curl -fsSL https://bun.sh/install | bash
-ENV PATH="/root/.bun/bin:$PATH"
-
-# Install Rust (needed to build native addon)
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly
-ENV PATH="/root/.cargo/bin:$PATH"
+ENV PATH="/root/.bun/bin:/root/.local/bin:$PATH"
 
 # Copy local repo
 WORKDIR /repo
 COPY . .
 
-# Install dependencies, build native addon, and link globally
-RUN bun install --frozen-lockfile
-RUN bun --cwd=packages/natives run build
-RUN cd packages/coding-agent && bun link
+# Exercise the public installer against an exact commit in this isolated repository.
+RUN git init -q && \
+    git config user.name "xcsh installer test" && \
+    git config user.email "xcsh-installer-test@example.com" && \
+    git add . && \
+    git add -f bun.lock && \
+    git commit -qm "test: source installer fixture"
+RUN XCSH_SOURCE_REPO_URL=/repo PI_INSTALL_DIR=/root/.local/bin \
+    bash scripts/install.sh --source --ref "$(git rev-parse HEAD)"
 
 # Verify
-RUN omp --version
+RUN xcsh --version

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -12,6 +12,7 @@ set -e
 
 REPO="f5-sales-demo/xcsh"
 PACKAGE="@f5-sales-demo/xcsh"
+SOURCE_REPO_URL="${XCSH_SOURCE_REPO_URL:-https://github.com/${REPO}.git}"
 INSTALL_DIR="${PI_INSTALL_DIR:-$HOME/.local/bin}"
 MIN_BUN_VERSION="1.3.7"
 BUN_INSTALL_VERSION="1.3.14"
@@ -189,6 +190,8 @@ install_bun() {
   chmod 0755 "$BUN_INSTALL/bin/bun"
   export PATH="$BUN_INSTALL/bin:$PATH"
   require_bun_version
+  rm -rf "$bun_tmp_dir"
+  trap - EXIT
 }
 
 # Check if git-lfs is available
@@ -205,30 +208,102 @@ install_via_bun() {
       exit 1
     fi
 
-    TMP_DIR="$(mktemp -d)"
-    trap 'rm -rf "$TMP_DIR"' EXIT
+    SOURCE_TMP_DIR="$(mktemp -d)"
+    INSTALL_STAGE_DIR=""
+    cleanup_source_install() {
+      if [ -n "$INSTALL_STAGE_DIR" ] && [ -d "$INSTALL_STAGE_DIR" ]; then
+        rm -rf "$INSTALL_STAGE_DIR"
+      fi
+      if [ -n "$SOURCE_TMP_DIR" ] && [ -d "$SOURCE_TMP_DIR" ]; then
+        rm -rf "$SOURCE_TMP_DIR"
+      fi
+    }
+    trap cleanup_source_install EXIT INT TERM
 
-    if git clone --depth 1 --branch "$REF" "https://github.com/${REPO}.git" "$TMP_DIR" >/dev/null 2>&1; then
-      :
-    else
-      git clone "https://github.com/${REPO}.git" "$TMP_DIR"
-      (cd "$TMP_DIR" && git checkout "$REF")
+    git -C "$SOURCE_TMP_DIR" init -q
+    git -C "$SOURCE_TMP_DIR" remote add origin "$SOURCE_REPO_URL"
+    if ! git -C "$SOURCE_TMP_DIR" fetch --depth 1 origin "$REF"; then
+      echo "Failed to fetch source ref: $REF"
+      exit 1
     fi
+    git -C "$SOURCE_TMP_DIR" checkout --detach -q FETCH_HEAD
 
     # Pull LFS files
     if has_git_lfs; then
-      (cd "$TMP_DIR" && git lfs pull)
+      (cd "$SOURCE_TMP_DIR" && git lfs pull)
     fi
 
-    if [ ! -d "$TMP_DIR/packages/coding-agent" ]; then
-      echo "Expected package at ${TMP_DIR}/packages/coding-agent"
+    if [ ! -d "$SOURCE_TMP_DIR/packages/coding-agent" ]; then
+      echo "Expected package at ${SOURCE_TMP_DIR}/packages/coding-agent"
       exit 1
     fi
 
-    bun install -g "$TMP_DIR/packages/coding-agent" || {
-      echo "Failed to install from source"
+    (cd "$SOURCE_TMP_DIR" && bun install --frozen-lockfile) || {
+      echo "Failed to install source workspace dependencies"
       exit 1
     }
+
+    case "$(uname -s)" in
+    Linux) native_platform="linux" ;;
+    Darwin) native_platform="darwin" ;;
+    *)
+      echo "Unsupported source installation platform: $(uname -s)"
+      exit 1
+      ;;
+    esac
+    case "$(uname -m)" in
+    x86_64 | amd64)
+      native_arch="x64"
+      native_addon_names="pi_natives.${native_platform}-${native_arch}-modern.node pi_natives.${native_platform}-${native_arch}-baseline.node"
+      ;;
+    arm64 | aarch64)
+      native_arch="arm64"
+      native_addon_names="pi_natives.${native_platform}-${native_arch}.node"
+      ;;
+    *)
+      echo "Unsupported source installation architecture: $(uname -m)"
+      exit 1
+      ;;
+    esac
+
+    mkdir -p "$SOURCE_TMP_DIR/packages/natives/native"
+    for native_addon_name in $native_addon_names; do
+      native_addon_source=$(find "$SOURCE_TMP_DIR/node_modules/.bun" -type f -name "$native_addon_name" -print -quit)
+      if [ -z "$native_addon_source" ]; then
+        echo "Installed platform package did not provide ${native_addon_name}"
+        exit 1
+      fi
+      cp "$native_addon_source" "$SOURCE_TMP_DIR/packages/natives/native/$native_addon_name"
+    done
+
+    (cd "$SOURCE_TMP_DIR" && bun --cwd=packages/coding-agent run build) || {
+      echo "Failed to compile xcsh from source"
+      exit 1
+    }
+
+    mkdir -p "$INSTALL_DIR"
+    INSTALL_STAGE_DIR="$(mktemp -d "$INSTALL_DIR/.xcsh-install.XXXXXX")"
+    cp "$SOURCE_TMP_DIR/packages/coding-agent/dist/xcsh" "$INSTALL_STAGE_DIR/xcsh"
+    chmod 0755 "$INSTALL_STAGE_DIR/xcsh"
+    for native_addon_name in $native_addon_names; do
+      cp "$SOURCE_TMP_DIR/packages/natives/native/$native_addon_name" "$INSTALL_STAGE_DIR/$native_addon_name"
+      mv -f "$INSTALL_STAGE_DIR/$native_addon_name" "$INSTALL_DIR/$native_addon_name"
+    done
+    mv -f "$INSTALL_STAGE_DIR/xcsh" "$INSTALL_DIR/xcsh"
+    rmdir "$INSTALL_STAGE_DIR"
+    INSTALL_STAGE_DIR=""
+    rm -rf "$SOURCE_TMP_DIR"
+    SOURCE_TMP_DIR=""
+    trap - EXIT INT TERM
+
+    echo ""
+    echo "✓ Installed xcsh from source to ${INSTALL_DIR}/xcsh"
+    echo "✓ Installed platform-native addons to ${INSTALL_DIR}"
+    case ":$PATH:" in
+    *":$INSTALL_DIR:"*) echo "Run 'xcsh' to get started!" ;;
+    *) echo "Add ${INSTALL_DIR} to your PATH, then run 'xcsh'" ;;
+    esac
+    return
   else
     bun install -g "$PACKAGE" || {
       echo "Failed to install $PACKAGE"


### PR DESCRIPTION
## Summary

Make exact-ref source installs self-contained and add a repeatable no-mock OpenAI subscription boundary UAT.

## Related Issue

Closes #3212

## Changes

- Install exact source refs from a frozen temporary workspace, stage the Bun-provided platform-native add-ons, compile xcsh, and atomically move standalone artifacts into `PI_INSTALL_DIR`.
- Add `XCSH_SOURCE_REPO_URL` for isolated installer tests and replace link-only source smokes with real local-repository installer coverage.
- Correct the Docker source smoke to install and verify `xcsh`.
- Add PTY-driven Bun/installed-xcsh OpenAI guidance checks plus official `codex login status` and ephemeral read-only `codex exec --model gpt-5.6` acceptance.
- Remove stale package documentation advertising unsupported OpenAI/ChatGPT OAuth.

## Verification evidence

- `bash scripts/install-tests/source-ref.sh` — passed; installed exact local-only commit, deleted the clone, and exercised the standalone binary/add-ons.
- `docker build --progress=plain -f scripts/install-tests/source.dockerfile ...` — passed; final output `xcsh/20.19.1`.
- Focused installer/OAuth selector/legacy credential/model recovery/regression tests — 156 passed, 0 failed.
- `bun run check:ts` — passed across all workspaces.
- `bun run test` — passed; coding-agent 6,607 passed / 559 skipped / 0 failed, all remaining workspaces 0 failed.
- `bun run ci:test:install-methods` — repaired source smoke passed; local binary smoke reached `xcsh/20.19.1`, then this scanner-only host failed three pre-existing sandbox enumeration checks. `--help`, stats, and spec discovery pass independently.
- `bun run uat:openai-subscription -- --source` — xcsh PTY boundary passed and `codex login status` reported ChatGPT authentication. The required exact official-Codex sentinel remains externally blocked: Codex returned HTTP 400, `The 'gpt-5.6' model is not supported when using Codex with a ChatGPT account.` The UAT fails closed and does not substitute another model or credential path.

## Delivery evidence

- Feature branch pushed; CI and auto-merge repair loop pending.
- Post-merge raw-main and published-release acceptance pending.

## Checklist

- [x] Linked to a detailed issue with `Closes #N`
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [ ] Tests written first (TDD) and passing; the issue's acceptance criteria are met (exact GPT-5.6 subscription sentinel is externally blocked as recorded above)
- [x] Verified locally by running or exercising the change — evidence pasted above

- [ ] Pending, failed, behind, or conflicted states repaired through `MERGED`
- [ ] Worktree and confirmed-merged branch cleaned; fleet convergence confirmed when applicable
- [x] Follows project conventions and style guides
