### PR TITLE
fix(release): add guarded npm backfill

### DIFF
--- a/.github/config/self-hosted-runner-policy.json
+++ b/.github/config/self-hosted-runner-policy.json
@@ -255,6 +255,12 @@
           "reason": "PII enforcement runs in an isolated hosted environment"
         }
       },
+      ".github/workflows/release-npm-backfill.yml": {
+        "backfill": {
+          "runs_on": "ubuntu-22.04",
+          "reason": "npm backfill publication uses hosted release credentials"
+        }
+      },
       ".github/workflows/release-reconcile.yml": {
         "reconcile": {
           "runs_on": "ubuntu-22.04",

--- a/.github/workflows/release-npm-backfill.yml
+++ b/.github/workflows/release-npm-backfill.yml
@@ -1,0 +1,191 @@
+---
+name: Release npm backfill
+run-name: Backfill npm ${{ inputs.tag }} from run ${{ inputs.source_run_id }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing immutable release tag (vX.Y.Z)"
+        required: true
+        type: string
+      source_run_id:
+        description: "Original CI tag run containing successful native artifacts"
+        required: true
+        type: string
+
+permissions:
+  actions: read # Required to inspect the source run and download its artifacts.
+  contents: read # Required to check out the controller and immutable tag.
+
+concurrency:
+  group: release-npm-backfill-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  backfill:
+    name: Backfill npm release
+    environment: release
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    permissions:
+      actions: read # Required to inspect the source run and download its artifacts.
+      contents: read # Required to check out the controller and immutable tag.
+      id-token: write # Required for npm publication provenance.
+    steps:
+      - name: Checkout trusted backfill controller
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Checkout immutable release source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.tag }}
+          path: .release-source
+          lfs: true
+
+      - name: Setup Bun 1.3
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          no-cache: true
+          bun-version: "1.3"
+
+      - name: Validate immutable tag, source run, and release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+            echo "::error::TAG must be an exact stable vX.Y.Z tag"
+            exit 1
+          }
+          [[ "$SOURCE_RUN_ID" =~ ^[0-9]+$ ]] || {
+            echo "::error::SOURCE_RUN_ID must be numeric"
+            exit 1
+          }
+
+          tag_sha=$(git -C .release-source rev-parse 'HEAD^{commit}')
+          run=$(gh api "repos/${REPOSITORY}/actions/runs/${SOURCE_RUN_ID}")
+          echo "$run" | jq -e \
+            --arg tag "$TAG" \
+            --arg tag_sha "$tag_sha" \
+            '.event == "push" and .head_branch == $tag and .head_sha == $tag_sha' >/dev/null || {
+              echo "::error::Source run is not the original push run for ${TAG}@${tag_sha}"
+              exit 1
+            }
+
+          attempt=$(echo "$run" | jq -r .run_attempt)
+          jobs=$(gh api "repos/${REPOSITORY}/actions/runs/${SOURCE_RUN_ID}/attempts/${attempt}/jobs?per_page=100")
+          echo "$jobs" | jq -e '
+            ([.jobs[] | select(.name == "check" or .name == "test" or .name == "Test installation methods")] | length == 3) and
+            (all(.jobs[] | select(.name == "check" or .name == "test" or .name == "Test installation methods"); .conclusion == "success")) and
+            ([.jobs[] | select(.name | startswith("Native build ("))] | length >= 8) and
+            (all(.jobs[] | select(.name | startswith("Native build (")); .conclusion == "success"))
+          ' >/dev/null || {
+            echo "::error::Source run lacks green check, test, installation, or native-build prerequisites"
+            exit 1
+          }
+
+          gh api "repos/${REPOSITORY}/releases/tags/${TAG}" \
+            | jq -e --arg tag "$TAG" '.tag_name == $tag and .draft == false and .prerelease == false and .immutable == true' \
+              >/dev/null || {
+                echo "::error::GitHub release for ${TAG} is absent, mutable, draft, or prerelease"
+                exit 1
+              }
+
+          version=${TAG#v}
+          test "$(jq -r .version .release-source/packages/coding-agent/package.json)" = "$version"
+          latest=$(npm view @f5-sales-demo/xcsh dist-tags.latest)
+          test -n "$latest"
+          {
+            echo "TAG_SHA=${tag_sha}"
+            echo "VERSION=${version}"
+            echo "LATEST_BEFORE=${latest}"
+          } >> "$GITHUB_ENV"
+
+      - name: Install immutable release dependencies
+        run: bun install --cwd .release-source --frozen-lockfile
+
+      - name: Download native addon artifacts from source run
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.source_run_id }}
+          pattern: pi-natives-*
+          path: .release-source/packages/natives/native
+          merge-multiple: true
+
+      - name: Stage native addons into platform packages
+        run: |
+          set -euo pipefail
+          native_dir=".release-source/packages/natives/native"
+          npm_dir=".release-source/packages/natives/npm"
+          cp "$native_dir/pi_natives.linux-x64-baseline.node" "$npm_dir/linux-x64-gnu/"
+          cp "$native_dir/pi_natives.linux-x64-modern.node" "$npm_dir/linux-x64-gnu/"
+          cp "$native_dir/pi_natives.linux-arm64.node" "$npm_dir/linux-arm64-gnu/"
+          cp "$native_dir/pi_natives.darwin-x64-baseline.node" "$npm_dir/darwin-x64/"
+          cp "$native_dir/pi_natives.darwin-x64-modern.node" "$npm_dir/darwin-x64/"
+          cp "$native_dir/pi_natives.darwin-arm64.node" "$npm_dir/darwin-arm64/"
+          cp "$native_dir/pi_natives.win32-x64-baseline.node" "$npm_dir/win32-x64-msvc/"
+          cp "$native_dir/pi_natives.win32-x64-modern.node" "$npm_dir/win32-x64-msvc/"
+          test "$(find "$npm_dir" -name '*.node' | wc -l)" -eq 8
+
+      - name: Publish missing versions without moving latest
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          XCSH_RELEASE_SOURCE_ROOT: ${{ github.workspace }}/.release-source
+        run: |
+          set -euo pipefail
+          umask 077
+          npmrc="$RUNNER_TEMP/npmrc"
+          trap 'rm -f "$npmrc"' EXIT
+          printf '//registry.npmjs.org/:_authToken=%s\n' "$NODE_AUTH_TOKEN" > "$npmrc"
+          export NPM_CONFIG_USERCONFIG="$npmrc"
+          bun scripts/ci-release-publish.ts --tag backfill
+
+      - name: Verify every package and preserve latest
+        run: |
+          set -euo pipefail
+          packages=(
+            @f5-sales-demo/pi-natives-linux-x64-gnu
+            @f5-sales-demo/pi-natives-linux-arm64-gnu
+            @f5-sales-demo/pi-natives-darwin-x64
+            @f5-sales-demo/pi-natives-darwin-arm64
+            @f5-sales-demo/pi-natives-win32-x64-msvc
+            @f5-sales-demo/pi-utils
+            @f5-sales-demo/pi-ai
+            @f5-sales-demo/pi-natives
+            @f5-sales-demo/pi-tui
+            @f5-sales-demo/xcsh-stats
+            @f5-sales-demo/pi-resource-management
+            @f5-sales-demo/pi-agent-core
+            @f5-sales-demo/xcsh
+          )
+          for attempt in $(seq 1 40); do
+            missing=0
+            for package in "${packages[@]}"; do
+              if ! test "$(npm view "${package}@${VERSION}" version 2>/dev/null || true)" = "$VERSION"; then
+                missing=1
+                break
+              fi
+            done
+            if [ "$missing" -eq 0 ]; then break; fi
+            if [ "$attempt" -eq 40 ]; then
+              echo "::error::One or more npm packages did not become visible for ${VERSION}"
+              exit 1
+            fi
+            sleep 15
+          done
+
+          for package in "${packages[@]}"; do
+            test "$(npm view "${package}@${VERSION}" version)" = "$VERSION"
+            test "$(npm view "${package}@${VERSION}" gitHead)" = "$TAG_SHA"
+          done
+          test "$(npm view "@f5-sales-demo/xcsh@${VERSION}" version)" = "$VERSION"
+          test "$(npm view @f5-sales-demo/xcsh dist-tags.backfill)" = "$VERSION"
+          test "$(npm view @f5-sales-demo/xcsh dist-tags.latest)" = "$LATEST_BEFORE"

--- a/packages/coding-agent/test/scripts/release-npm-backfill.test.ts
+++ b/packages/coding-agent/test/scripts/release-npm-backfill.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { isAlreadyPublished, npmPublishArgs, resolveReleaseSourceRoot } from "../../../../scripts/ci-release-publish";
+
+const root = path.resolve(import.meta.dir, "../../../..");
+const workflowPath = path.join(root, ".github/workflows/release-npm-backfill.yml");
+
+describe("release npm backfill publish semantics", () => {
+	it("does not misclassify a lower-than-latest dist-tag rejection as already published", () => {
+		const output =
+			'npm error Cannot implicitly apply the "latest" tag because previously published version 20.19.3 is higher than the new version 20.13.1. You must specify a tag using --tag.';
+		expect(isAlreadyPublished(output, "20.13.1")).toBe(false);
+	});
+
+	it("recognizes only an exact existing-version conflict", () => {
+		const output = "npm error EPUBLISHCONFLICT Cannot publish over previously published version 20.13.1.";
+		expect(isAlreadyPublished(output, "20.13.1")).toBe(true);
+		expect(isAlreadyPublished(output, "20.15.0")).toBe(false);
+	});
+
+	it("adds an explicit non-latest dist-tag for backfills", () => {
+		expect(npmPublishArgs()).toEqual(["npm", "publish", "--access", "public"]);
+		expect(npmPublishArgs("backfill")).toEqual(["npm", "publish", "--access", "public", "--tag", "backfill"]);
+	});
+
+	it("rejects malformed or latest backfill tags", () => {
+		expect(() => npmPublishArgs("latest")).toThrow(/latest/);
+		expect(() => npmPublishArgs("bad tag")).toThrow(/dist-tag/);
+	});
+
+	it("requires an absolute isolated release-source root", () => {
+		expect(resolveReleaseSourceRoot("/tmp/release-source")).toBe("/tmp/release-source");
+		expect(() => resolveReleaseSourceRoot("release-source")).toThrow(/absolute/);
+	});
+});
+
+describe("release npm backfill workflow contract", () => {
+	it("binds a manual backfill to an immutable tag and original run", async () => {
+		const workflow = await fs.readFile(workflowPath, "utf8");
+		expect(workflow).toContain("workflow_dispatch:");
+		expect(workflow).toContain("tag:");
+		expect(workflow).toContain("source_run_id:");
+		expect(workflow).toContain('event == "push"');
+		expect(workflow).toContain("head_branch == $tag");
+		expect(workflow).toContain("head_sha == $tag_sha");
+		expect(workflow).toContain(".immutable == true");
+		expect(workflow).toContain('select(.name == "check" or .name == "test" or .name == "Test installation methods")');
+		expect(workflow).toContain('select(.name | startswith("Native build ("))');
+	});
+
+	it("publishes from the isolated tag checkout without moving latest", async () => {
+		const workflow = await fs.readFile(workflowPath, "utf8");
+		expect(workflow).toContain("path: .release-source");
+		expect(workflow).toContain("XCSH_RELEASE_SOURCE_ROOT:");
+		expect(workflow).toContain("bun scripts/ci-release-publish.ts --tag backfill");
+		expect(workflow).toContain("NPM_TOKEN");
+		expect(workflow).toContain("dist-tags.latest");
+		expect(workflow).toContain("LATEST_BEFORE");
+		expect(workflow).toContain("@f5-sales-demo/xcsh@");
+	});
+});

--- a/packages/coding-agent/test/workflow-action-pins.test.ts
+++ b/packages/coding-agent/test/workflow-action-pins.test.ts
@@ -29,6 +29,7 @@ const WORKFLOW_DIR = path.join(import.meta.dir, "../../../.github/workflows");
 /** Workflows that reference a publishing or write credential — the ones that matter. */
 const CREDENTIAL_BEARING = [
 	"ci.yml",
+	"release-npm-backfill.yml",
 	"api-spec-update.yml",
 	"console-catalog-drift.yml",
 	"console-catalog-update.yml",

--- a/scripts/ci-release-publish.ts
+++ b/scripts/ci-release-publish.ts
@@ -18,8 +18,36 @@ export interface PackageJson {
 	optionalDependencies?: Record<string, string>;
 }
 
-const repoRoot = path.join(import.meta.dir, "..");
+export function resolveReleaseSourceRoot(sourceRoot?: string): string {
+	if (sourceRoot === undefined || sourceRoot.length === 0) return path.join(import.meta.dir, "..");
+	if (!path.isAbsolute(sourceRoot)) throw new Error("XCSH_RELEASE_SOURCE_ROOT must be an absolute path");
+	return path.normalize(sourceRoot);
+}
+
+function readOption(args: string[], name: string): string | undefined {
+	const index = args.indexOf(name);
+	if (index === -1) return undefined;
+	const value = args[index + 1];
+	if (value === undefined || value.startsWith("--")) throw new Error(`${name} requires a value`);
+	return value;
+}
+
+export function npmPublishArgs(distTag?: string): string[] {
+	const args = ["npm", "publish", "--access", "public"];
+	if (distTag === undefined) return args;
+	if (distTag === "latest") throw new Error("An explicit latest dist-tag is not allowed for release backfills");
+	if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(distTag)) {
+		throw new Error(`Malformed npm dist-tag: ${distTag}`);
+	}
+	return [...args, "--tag", distTag];
+}
+
+const repoRoot = resolveReleaseSourceRoot(process.env.XCSH_RELEASE_SOURCE_ROOT);
 const isDryRun = process.argv.includes("--dry-run");
+const publishTag = readOption(process.argv.slice(2), "--tag");
+// Validate once before touching any package or registry.
+npmPublishArgs(publishTag);
+
 // Platform-specific native addon packages (published first so optionalDependencies resolve)
 const platformPackageDirs: PublishPackage[] = [
 	{ dir: "packages/natives/npm/linux-x64-gnu" },
@@ -39,14 +67,13 @@ const packageDirs: PublishPackage[] = [
 	{ dir: "packages/agent" },
 	{ dir: "packages/coding-agent" },
 ];
-const alreadyPublishedPatterns = [
-	"previously published",
-	"cannot publish over",
-	"You cannot publish over",
-];
 
-function isAlreadyPublished(output: string): boolean {
-	return alreadyPublishedPatterns.some((pattern) => output.includes(pattern));
+export function isAlreadyPublished(output: string, version: string): boolean {
+	const escapedVersion = version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	return [
+		new RegExp(`cannot publish over (?:the )?previously published versions?:?\\s*["']?${escapedVersion}["']?`, "i"),
+		new RegExp(`cannot publish over (?:an )?existing version:?\\s*["']?${escapedVersion}["']?`, "i"),
+	].some(pattern => pattern.test(output));
 }
 
 async function readPackageJson(packageDir: string): Promise<PackageJson> {
@@ -117,7 +144,7 @@ async function publishPackage(pkg: PublishPackage): Promise<void> {
 	}
 
 	if (isDryRun) {
-		console.log(`DRY RUN npm publish --access public (${pkg.dir})`);
+		console.log(`DRY RUN ${npmPublishArgs(publishTag).join(" ")} (${pkg.dir})`);
 		return;
 	}
 
@@ -130,14 +157,15 @@ async function publishPackage(pkg: PublishPackage): Promise<void> {
 		let delay = 5_000;
 		for (let attempt = 1; attempt <= maxAttempts; attempt++) {
 			console.log(`Publishing ${packageName}... (attempt ${attempt}/${maxAttempts})`);
-			const result = await $`npm publish --access public`.cwd(path.join(repoRoot, pkg.dir)).quiet().nothrow();
+			const publishArgs = npmPublishArgs(publishTag);
+			const result = await $`${publishArgs}`.cwd(path.join(repoRoot, pkg.dir)).quiet().nothrow();
 			const output = `${result.stdout.toString()}${result.stderr.toString()}`.trim();
 			if (result.exitCode === 0) {
 				if (output) console.log(output);
 				return;
 			}
 			if (output) console.log(output);
-			if (isAlreadyPublished(output)) {
+			if (isAlreadyPublished(output, packageJson.version ?? "")) {
 				console.log("Already published, skipping");
 				return;
 			}


### PR DESCRIPTION
## What

- add a guarded manual workflow that backfills missing npm publications from an exact immutable release tag and its original CI run
- publish historical versions under the explicit `backfill` dist-tag without moving `latest`
- tighten exact-version conflict detection so a newer published `latest` version is not mistaken for the requested version
- verify all 13 package versions, `gitHead` values, release metadata, source-run prerequisites, and immutable action pins
- register the hosted release-credential route in the runner policy

## Why

The `v20.13.1` release pipeline created its GitHub release and Homebrew publication, but npm rejected the older version because no non-`latest` tag was supplied. The publisher then treated npm's reference to a newer previously published version as if `20.13.1` already existed. This left both `v20.13.1` and `v20.15.0` absent from npm and Release Reconciliation red.

## Testing

- `actionlint .github/workflows/release-npm-backfill.yml`
- 18 focused workflow/publisher tests: 18 pass, 0 fail
- runner-routing audit: pass
- governed zizmor workflow-security audit: pass
- `bun run check`: pass
- `bun run lint`: pass
- `bun run test`: pass, including 7,194 coding-agent tests with 0 failures
- `scripts/agy-review.sh code --base origin/main`: two independent schema-valid approvals, 0 findings

Closes #3222
