### PR TITLE
feat(auth): add ChatGPT device login for SSH

### DIFF
--- a/docs/en/providers/openai-api-access.md
+++ b/docs/en/providers/openai-api-access.md
@@ -10,11 +10,27 @@ xcsh offers two separate OpenAI providers. Start xcsh without a configured provi
 
 ## ChatGPT subscription
 
-Choose **ChatGPT Plus/Pro (Codex Subscription)**, or run `/login openai-codex`. xcsh opens the ChatGPT OAuth flow and stores the resulting credential in its credential database. It then discovers the models advertised for that ChatGPT account.
+Choose **ChatGPT Plus/Pro (Codex Subscription)**, or run `/login openai-codex`. xcsh stores the resulting credential in its credential database and discovers the models advertised for that ChatGPT account.
+
+### SSH and headless login
+
+In an SSH or headless terminal, `/login openai-codex` uses device-code authentication automatically:
+
+1. xcsh prints `https://auth.openai.com/codex/device` and a short one-time code.
+2. Open that page in any ordinary browser, including a managed workstation browser, and sign in.
+3. Enter the one-time code. The xcsh process on the remote host detects approval and completes login.
+
+The browser workstation does not need xcsh or Codex installed. This flow does not open port 1455, use an SSH tunnel, or require copying a redirect URL. Continue only when you initiated the displayed code from your own xcsh session.
+
+Device-code login is an OpenAI beta feature. It must be enabled under ChatGPT **Settings → Security**, or by a workspace administrator under **Workspace settings → Permissions & roles**. If it is disabled, xcsh explains the setting and leaves the browser callback method available. See [OpenAI's headless authentication guidance](https://learn.chatgpt.com/docs/auth#preferred-device-code-authentication-beta).
+
+### Local browser callback
+
+On a local graphical desktop, `/login openai-codex` keeps using browser PKCE. To choose that method explicitly, select **ChatGPT Plus/Pro (Browser callback)** or run `/login openai-codex-browser`.
 
 When the account advertises the complete GPT-5.6 family, xcsh selects `openai-codex/gpt-5.6-terra` with medium reasoning and configures Luna, Terra, and Sol for its subscription routing roles.
 
-The browser callback uses `http://localhost:1455/auth/callback`. Port 1455 must be available while login is running. If the browser cannot reach the callback directly, copy the complete redirect URL and submit it with `/login <redirect-url>` in the waiting xcsh session.
+The browser callback uses `http://localhost:1455/auth/callback`. Port 1455 must be available while login is running. The manual `/login <redirect-url>` fallback remains available, but device-code login is the intended method when the browser and xcsh run on different hosts.
 
 Credentials disabled by the OpenAI OAuth regression in v20.19.1 are reactivated automatically. Credentials disabled because they were deleted, invalid, expired, or failed for another reason remain disabled.
 

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -47,7 +47,7 @@ Unified LLM API with automatic model discovery, provider configuration, token an
 ## Supported Providers
 
 - **OpenAI** (usage-based Platform API access through `OPENAI_API_KEY`)
-- **OpenAI Codex** (ChatGPT Plus/Pro subscription through browser OAuth)
+- **OpenAI Codex** (ChatGPT Plus/Pro subscription through device-code or browser OAuth)
 - **Anthropic**
 - **Google**
 - **Vertex AI** (Gemini via Vertex AI)
@@ -1047,7 +1047,7 @@ bunx @f5-sales-demo/pi-ai list               # list available providers
 Credentials are saved to `agent.db` in the agent directory. `/login qianfan` opens the Qianfan console and stores the pasted API key.
 
 `login` supports OAuth providers (Anthropic, GitHub Copilot, Gemini CLI, Antigravity) and API-key onboarding flows.
-OpenAI has two credential paths. Use `OPENAI_API_KEY` for usage-based Platform API access. Use `login openai-codex` for ChatGPT Plus/Pro subscription OAuth; `login openai` explains the API-key path.
+OpenAI has two credential paths. Use `OPENAI_API_KEY` for usage-based Platform API access. Use `login openai-codex` for ChatGPT Plus/Pro subscription OAuth; SSH/headless terminals automatically receive a short device code, while local desktops use browser PKCE. Use `login openai-codex-browser` to force the callback flow. `login openai` explains the API-key path.
 
 For the current OpenAI-compatible integrations, API-key onboarding covers Together, Moonshot, Qianfan, NVIDIA, NanoGPT, Hugging Face, Venice, Xiaomi, vLLM, LiteLLM, Cloudflare AI Gateway, and Qwen Portal. Ollama is typically local and unauthenticated; set `OLLAMA_API_KEY` only when your Ollama deployment enforces bearer auth.
 
@@ -1139,7 +1139,7 @@ const response = await complete(
 
 ### Provider Notes
 
-**OpenAI**: Set `OPENAI_API_KEY` for usage-based Platform API access, or use the `openai-codex` OAuth provider for ChatGPT Plus/Pro subscription access.
+**OpenAI**: Set `OPENAI_API_KEY` for usage-based Platform API access, or use the `openai-codex` OAuth provider for ChatGPT Plus/Pro subscription access. Remote terminals use device-code authentication without a tunnel or localhost callback.
 
 **GitHub Copilot**: If you get "The requested model is not supported" error, enable the model manually in VS Code: open Copilot Chat, click the model selector, select the model (warning icon), and click "Enable".
 

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -821,6 +821,13 @@ export class AuthStorage {
 					onManualCodeInput: ctrl.onManualCodeInput ?? manualCodeInput,
 				});
 				break;
+			case "openai-codex-browser":
+				credentials = await loginOpenAICodex({
+					...ctrl,
+					method: "browser",
+					onManualCodeInput: ctrl.onManualCodeInput ?? manualCodeInput,
+				});
+				break;
 			case "openai":
 				throw new Error("OpenAI uses usage-based API access. Set OPENAI_API_KEY instead of signing in.");
 			case "gitlab-duo":

--- a/packages/ai/src/cli.ts
+++ b/packages/ai/src/cli.ts
@@ -15,7 +15,7 @@ import { loginNanoGPT } from "./utils/oauth/nanogpt";
 import { loginOpenAICodex } from "./utils/oauth/openai-codex";
 import { loginParallel } from "./utils/oauth/parallel";
 import { loginTavily } from "./utils/oauth/tavily";
-import type { OAuthCredentials, OAuthProvider } from "./utils/oauth/types";
+import { canonicalizeOAuthProviderId, type OAuthCredentials, type OAuthProvider } from "./utils/oauth/types";
 import { loginZai } from "./utils/oauth/zai";
 import { loginZenMux } from "./utils/oauth/zenmux";
 
@@ -129,6 +129,20 @@ async function login(provider: OAuthProvider): Promise<void> {
 				break;
 			case "openai-codex":
 				credentials = await loginOpenAICodex({
+					onAuth(info) {
+						const { url, instructions } = info;
+						console.log(`\nOpen this URL in your browser:\n${url}`);
+						if (instructions) console.log(instructions);
+						console.log();
+					},
+					async onPrompt(p) {
+						return await promptFn(`${p.message}${p.placeholder ? ` (${p.placeholder})` : ""}:`);
+					},
+				});
+				break;
+			case "openai-codex-browser":
+				credentials = await loginOpenAICodex({
+					method: "browser",
 					onAuth(info) {
 						const { url, instructions } = info;
 						console.log(`\nOpen this URL in your browser:\n${url}`);
@@ -309,7 +323,7 @@ async function login(provider: OAuthProvider): Promise<void> {
 				throw new Error(`Unknown provider: ${provider}`);
 		}
 
-		storage.saveOAuth(provider, credentials);
+		storage.saveOAuth(canonicalizeOAuthProviderId(provider), credentials);
 
 		console.log(`\nCredentials saved to ~/.xcsh/agent/agent.db`);
 	} finally {
@@ -337,6 +351,7 @@ Providers:
   google-gemini-cli Google Gemini CLI
   google-antigravity Antigravity (Gemini 3, Claude, GPT-OSS)
   openai-codex      ChatGPT Plus/Pro (Codex subscription)
+  openai-codex-browser ChatGPT Plus/Pro (explicit browser callback)
   openai            OpenAI Responses API (usage-based; set OPENAI_API_KEY)
   kimi-code         Kimi Code
   kilo              Kilo Gateway

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -97,9 +97,19 @@ export { loginNanoGPT } from "./nanogpt";
 export { loginNvidia } from "./nvidia";
 // Ollama (optional API key)
 export { loginOllama } from "./ollama";
-export type { OpenAICodexLoginOptions } from "./openai-codex";
+export type {
+	OpenAICodexDeviceFlowDependencies,
+	OpenAICodexLoginMethod,
+	OpenAICodexLoginOptions,
+} from "./openai-codex";
 // OpenAI Codex (ChatGPT OAuth)
-export { loginOpenAICodex, refreshOpenAICodexToken } from "./openai-codex";
+export {
+	loginOpenAICodex,
+	loginOpenAICodexDevice,
+	refreshOpenAICodexToken,
+	resolveOpenAICodexLoginMethod,
+	shouldUseOpenAICodexDeviceFlow,
+} from "./openai-codex";
 // OpenCode Zen / OpenCode Go (API key)
 export { loginOpenCode } from "./opencode";
 // Parallel (API key)
@@ -145,6 +155,13 @@ const builtInOAuthProviders: OAuthProviderInfo[] = [
 		id: "openai-codex",
 		name: "ChatGPT Plus/Pro (Codex Subscription)",
 		available: true,
+	},
+	{
+		id: "openai-codex-browser",
+		name: "ChatGPT Plus/Pro (Browser callback)",
+		available: true,
+		canonicalId: "openai-codex",
+		loginOnly: true,
 	},
 	{
 		id: "openai",

--- a/packages/ai/src/utils/oauth/openai-codex.ts
+++ b/packages/ai/src/utils/oauth/openai-codex.ts
@@ -85,6 +85,17 @@ function describeTokenEndpointValue(value: unknown): string | undefined {
 	return code ?? message;
 }
 
+function parseOAuthErrorCode(bodyText: string): string | undefined {
+	try {
+		const body: unknown = JSON.parse(bodyText);
+		if (!isRecord(body)) return undefined;
+		const value = body.error;
+		return typeof value === "string" ? value.trim().toLowerCase() : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
 function redactTokenEndpointDetail(detail: string): string {
 	return detail
 		.replace(/(https?:\/\/[^\s?]+)\?[^\s)]+/gi, "$1?[REDACTED]")
@@ -273,7 +284,7 @@ export async function loginOpenAICodexDevice(
 	}
 
 	const parsedInterval = Number.parseInt(String(initData.interval ?? "5"), 10);
-	const pollIntervalMs = Math.max(1_000, (Number.isFinite(parsedInterval) ? parsedInterval : 5) * 1_000);
+	let pollIntervalMs = Math.max(1_000, (Number.isFinite(parsedInterval) ? parsedInterval : 5) * 1_000);
 	const deadline = now() + DEVICE_FLOW_TIMEOUT_MS;
 	options.onAuth?.({
 		url: DEVICE_AUTH_URL,
@@ -295,7 +306,13 @@ export async function loginOpenAICodexDevice(
 			continue;
 		}
 		if (!pollResponse.ok) {
-			const detail = formatOpenAICodexTokenEndpointError(pollResponse.status, await pollResponse.text());
+			const bodyText = await pollResponse.text();
+			if (parseOAuthErrorCode(bodyText) === "slow_down") {
+				pollIntervalMs += 5_000;
+				await sleep(pollIntervalMs, options.signal);
+				continue;
+			}
+			const detail = formatOpenAICodexTokenEndpointError(pollResponse.status, bodyText);
 			throw new Error(`Device token polling failed: ${detail}`);
 		}
 

--- a/packages/ai/src/utils/oauth/openai-codex.ts
+++ b/packages/ai/src/utils/oauth/openai-codex.ts
@@ -301,18 +301,25 @@ export async function loginOpenAICodexDevice(
 			signal: AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS),
 		});
 
-		if (pollResponse.status === 403 || pollResponse.status === 404) {
-			await sleep(pollIntervalMs, options.signal);
-			continue;
-		}
 		if (!pollResponse.ok) {
 			const bodyText = await pollResponse.text();
-			if (parseOAuthErrorCode(bodyText) === "slow_down") {
+			const errorCode = parseOAuthErrorCode(bodyText);
+			const detail = formatOpenAICodexTokenEndpointError(pollResponse.status, bodyText);
+			if (errorCode === "authorization_declined" || errorCode === "access_denied") {
+				throw new Error(`Device authorization denied: ${detail}`);
+			}
+			if (errorCode === "expired_token" || errorCode === "authorization_expired") {
+				throw new Error(`Device authorization expired: ${detail}`);
+			}
+			if (errorCode === "slow_down") {
 				pollIntervalMs += 5_000;
 				await sleep(pollIntervalMs, options.signal);
 				continue;
 			}
-			const detail = formatOpenAICodexTokenEndpointError(pollResponse.status, bodyText);
+			if (errorCode === "authorization_pending" || pollResponse.status === 403 || pollResponse.status === 404) {
+				await sleep(pollIntervalMs, options.signal);
+				continue;
+			}
 			throw new Error(`Device token polling failed: ${detail}`);
 		}
 

--- a/packages/ai/src/utils/oauth/openai-codex.ts
+++ b/packages/ai/src/utils/oauth/openai-codex.ts
@@ -113,7 +113,7 @@ function redactTokenEndpointDetail(detail: string): string {
 		.replace(/(https?:\/\/[^\s?]+)\?[^\s)]+/gi, "$1?[REDACTED]")
 		.replace(/\bBearer\s+[^\s,;]+/gi, "Bearer [REDACTED]")
 		.replace(
-			/\b(access_token|refresh_token|id_token|authorization_code|code|token|state)\b(\s*[:=]\s*)(?:"[^"]*"|'[^']*'|[^\s,;]+)/gi,
+			/\b(access_token|refresh_token|id_token|authorization_code|code_verifier|device_auth_id|user_code|code|token|state)\b(\s*[:=]\s*)(?:"[^"]*"|'[^']*'|[^\s,;]+)/gi,
 			"$1$2[REDACTED]",
 		)
 		.replace(/\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g, "[REDACTED]")

--- a/packages/ai/src/utils/oauth/openai-codex.ts
+++ b/packages/ai/src/utils/oauth/openai-codex.ts
@@ -261,6 +261,7 @@ export async function loginOpenAICodexDevice(
 	const fetchImpl = dependencies.fetch ?? fetch;
 	const sleep = dependencies.sleep ?? abortableSleep;
 	const now = dependencies.now ?? Date.now;
+	if (options.signal?.aborted) throw new Error("Device authorization cancelled");
 	options.onProgress?.("Requesting a ChatGPT device code…");
 
 	const initResponse = await fetchImpl(DEVICE_USER_CODE_URL, {

--- a/packages/ai/src/utils/oauth/openai-codex.ts
+++ b/packages/ai/src/utils/oauth/openai-codex.ts
@@ -17,6 +17,16 @@ const JWT_CLAIM_PATH = "https://api.openai.com/auth";
 const JWT_PROFILE_CLAIM = "https://api.openai.com/profile";
 const TOKEN_REQUEST_TIMEOUT_MS = 15_000;
 
+/** Prefer callback-free authentication when xcsh is running in a remote terminal. */
+export function shouldUseOpenAICodexDeviceFlow(
+	env: NodeJS.ProcessEnv = process.env,
+	platform: NodeJS.Platform = process.platform,
+	isInteractive = Boolean(process.stdin.isTTY),
+): boolean {
+	if (env.SSH_CONNECTION || env.SSH_CLIENT || env.SSH_TTY) return true;
+	return platform === "linux" && isInteractive && !env.DISPLAY && !env.WAYLAND_DISPLAY;
+}
+
 type JwtPayload = {
 	[JWT_CLAIM_PATH]?: {
 		chatgpt_account_id?: string;

--- a/packages/ai/src/utils/oauth/openai-codex.ts
+++ b/packages/ai/src/utils/oauth/openai-codex.ts
@@ -1,6 +1,7 @@
 /**
  * OpenAI Codex (ChatGPT OAuth) flow.
  */
+import { abortableSleep } from "@f5-sales-demo/pi-utils";
 import { isRecord } from "../../utils";
 import { OAuthCallbackFlow, type OAuthCallbackFlowOptions } from "./callback-server";
 import { generatePKCE } from "./pkce";
@@ -16,6 +17,11 @@ const SCOPE = "openid profile email offline_access api.connectors.read api.conne
 const JWT_CLAIM_PATH = "https://api.openai.com/auth";
 const JWT_PROFILE_CLAIM = "https://api.openai.com/profile";
 const TOKEN_REQUEST_TIMEOUT_MS = 15_000;
+const DEVICE_USER_CODE_URL = "https://auth.openai.com/api/accounts/deviceauth/usercode";
+const DEVICE_TOKEN_URL = "https://auth.openai.com/api/accounts/deviceauth/token";
+const DEVICE_AUTH_URL = "https://auth.openai.com/codex/device";
+const DEVICE_REDIRECT_URI = "https://auth.openai.com/deviceauth/callback";
+const DEVICE_FLOW_TIMEOUT_MS = 15 * 60 * 1000;
 
 /** Prefer callback-free authentication when xcsh is running in a remote terminal. */
 export function shouldUseOpenAICodexDeviceFlow(
@@ -170,8 +176,13 @@ class OpenAICodexOAuthFlow extends OAuthCallbackFlow {
 	}
 }
 
-async function exchangeCodeForToken(code: string, verifier: string, redirectUri: string): Promise<OAuthCredentials> {
-	const tokenResponse = await fetch(TOKEN_URL, {
+async function exchangeCodeForToken(
+	code: string,
+	verifier: string,
+	redirectUri: string,
+	fetchImpl: typeof fetch = fetch,
+): Promise<OAuthCredentials> {
+	const tokenResponse = await fetchImpl(TOKEN_URL, {
 		method: "POST",
 		headers: { "Content-Type": "application/x-www-form-urlencoded" },
 		body: new URLSearchParams({
@@ -223,6 +234,83 @@ export async function loginOpenAICodex(options: OpenAICodexLoginOptions): Promis
 	const originator = options.originator?.trim() || "pi";
 	const flow = new OpenAICodexOAuthFlow(options, pkce, originator);
 	return flow.login();
+}
+
+export type OpenAICodexDeviceFlowDependencies = {
+	fetch?: typeof fetch;
+	sleep?: (milliseconds: number, signal?: AbortSignal) => Promise<void>;
+	now?: () => number;
+};
+
+/** Authenticate ChatGPT without opening a local callback listener. */
+export async function loginOpenAICodexDevice(
+	options: OAuthController,
+	dependencies: OpenAICodexDeviceFlowDependencies = {},
+): Promise<OAuthCredentials> {
+	const fetchImpl = dependencies.fetch ?? fetch;
+	const sleep = dependencies.sleep ?? abortableSleep;
+	const now = dependencies.now ?? Date.now;
+	options.onProgress?.("Requesting a ChatGPT device code…");
+
+	const initResponse = await fetchImpl(DEVICE_USER_CODE_URL, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ client_id: CLIENT_ID }),
+		signal: AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS),
+	});
+	if (!initResponse.ok) {
+		const detail = formatOpenAICodexTokenEndpointError(initResponse.status, await initResponse.text());
+		throw new Error(`Device authorization initiation failed: ${detail}`);
+	}
+
+	const initData = (await initResponse.json()) as {
+		device_auth_id?: string;
+		user_code?: string;
+		interval?: string | number;
+	};
+	if (!initData.device_auth_id || !initData.user_code) {
+		throw new Error("Device authorization response missing required fields");
+	}
+
+	const parsedInterval = Number.parseInt(String(initData.interval ?? "5"), 10);
+	const pollIntervalMs = Math.max(1_000, (Number.isFinite(parsedInterval) ? parsedInterval : 5) * 1_000);
+	const deadline = now() + DEVICE_FLOW_TIMEOUT_MS;
+	options.onAuth?.({
+		url: DEVICE_AUTH_URL,
+		instructions: `Enter this one-time code: ${initData.user_code} (expires in 15 minutes)`,
+	});
+	options.onProgress?.("Waiting for approval in your browser…");
+
+	while (now() < deadline) {
+		if (options.signal?.aborted) throw new Error("Device authorization cancelled");
+		const pollResponse = await fetchImpl(DEVICE_TOKEN_URL, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ device_auth_id: initData.device_auth_id, user_code: initData.user_code }),
+			signal: AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS),
+		});
+
+		if (pollResponse.status === 403 || pollResponse.status === 404) {
+			await sleep(pollIntervalMs, options.signal);
+			continue;
+		}
+		if (!pollResponse.ok) {
+			const detail = formatOpenAICodexTokenEndpointError(pollResponse.status, await pollResponse.text());
+			throw new Error(`Device token polling failed: ${detail}`);
+		}
+
+		const pollData = (await pollResponse.json()) as {
+			authorization_code?: string;
+			code_verifier?: string;
+		};
+		if (!pollData.authorization_code || !pollData.code_verifier) {
+			throw new Error("Device token response missing authorization code or verifier");
+		}
+		options.onProgress?.("Completing ChatGPT authentication…");
+		return exchangeCodeForToken(pollData.authorization_code, pollData.code_verifier, DEVICE_REDIRECT_URI, fetchImpl);
+	}
+
+	throw new Error("Device authorization expired after 15 minutes");
 }
 
 export async function refreshOpenAICodexToken(refreshToken: string): Promise<OAuthCredentials> {

--- a/packages/ai/src/utils/oauth/openai-codex.ts
+++ b/packages/ai/src/utils/oauth/openai-codex.ts
@@ -33,6 +33,18 @@ export function shouldUseOpenAICodexDeviceFlow(
 	return platform === "linux" && isInteractive && !env.DISPLAY && !env.WAYLAND_DISPLAY;
 }
 
+export type OpenAICodexLoginMethod = "auto" | "browser" | "device";
+
+export function resolveOpenAICodexLoginMethod(
+	method: OpenAICodexLoginMethod = "auto",
+	env: NodeJS.ProcessEnv = process.env,
+	platform: NodeJS.Platform = process.platform,
+	isInteractive = Boolean(process.stdin.isTTY),
+): Exclude<OpenAICodexLoginMethod, "auto"> {
+	if (method !== "auto") return method;
+	return shouldUseOpenAICodexDeviceFlow(env, platform, isInteractive) ? "device" : "browser";
+}
+
 type JwtPayload = {
 	[JWT_CLAIM_PATH]?: {
 		chatgpt_account_id?: string;
@@ -238,9 +250,14 @@ async function exchangeCodeForToken(
 export type OpenAICodexLoginOptions = OAuthController & {
 	/** Optional originator value. The default matches xcsh Codex request headers. */
 	originator?: string;
+	/** Automatic uses device authorization in SSH/headless terminals and browser PKCE locally. */
+	method?: OpenAICodexLoginMethod;
 };
 
 export async function loginOpenAICodex(options: OpenAICodexLoginOptions): Promise<OAuthCredentials> {
+	if (resolveOpenAICodexLoginMethod(options.method) === "device") {
+		return loginOpenAICodexDevice(options);
+	}
 	const pkce = await generatePKCE();
 	const originator = options.originator?.trim() || "pi";
 	const flow = new OpenAICodexOAuthFlow(options, pkce, originator);

--- a/packages/ai/src/utils/oauth/openai-codex.ts
+++ b/packages/ai/src/utils/oauth/openai-codex.ts
@@ -288,6 +288,11 @@ export async function loginOpenAICodexDevice(
 		signal: AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS),
 	});
 	if (!initResponse.ok) {
+		if (initResponse.status === 404) {
+			throw new Error(
+				"Device-code login is not enabled for this ChatGPT account or workspace. Enable it in ChatGPT security or workspace settings, or choose the browser callback login.",
+			);
+		}
 		const detail = formatOpenAICodexTokenEndpointError(initResponse.status, await initResponse.text());
 		throw new Error(`Device authorization initiation failed: ${detail}`);
 	}

--- a/packages/ai/src/utils/oauth/types.ts
+++ b/packages/ai/src/utils/oauth/types.ts
@@ -35,6 +35,7 @@ export type OAuthProvider =
 	| "ollama"
 	| "openai"
 	| "openai-codex"
+	| "openai-codex-browser"
 	| "opencode-go"
 	| "opencode-zen"
 	| "parallel"
@@ -78,7 +79,9 @@ export interface OAuthProviderInfo {
 
 /** Resolve login-only aliases to the provider ID used by credentials and models. */
 export function canonicalizeOAuthProviderId(provider: string): string {
-	return provider === "google-antigravity-enterprise" ? "google-antigravity" : provider;
+	if (provider === "google-antigravity-enterprise") return "google-antigravity";
+	if (provider === "openai-codex-browser") return "openai-codex";
+	return provider;
 }
 
 export interface OAuthController {

--- a/packages/ai/test/auth-storage-codex-browser-alias.test.ts
+++ b/packages/ai/test/auth-storage-codex-browser-alias.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AuthCredentialStore, AuthStorage } from "../src/auth-storage";
+import * as openAICodexModule from "../src/utils/oauth/openai-codex";
+
+const CREDENTIALS = {
+	refresh: "refresh-token",
+	access: "access-token",
+	expires: Date.now() + 60_000,
+	accountId: "chatgpt-account",
+	email: "developer@example.com",
+};
+
+describe("AuthStorage OpenAI Codex browser alias", () => {
+	let temporaryDirectory = "";
+	let store: AuthCredentialStore | undefined;
+	let authStorage: AuthStorage | undefined;
+
+	beforeEach(async () => {
+		temporaryDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-codex-browser-"));
+		store = await AuthCredentialStore.open(path.join(temporaryDirectory, "agent.db"));
+		authStorage = new AuthStorage(store);
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		store?.close();
+		store = undefined;
+		authStorage = undefined;
+		if (temporaryDirectory) await fs.rm(temporaryDirectory, { recursive: true, force: true });
+	});
+
+	it("forces browser PKCE and persists credentials under the canonical provider", async () => {
+		if (!authStorage || !store) throw new Error("test setup failed");
+		const login = vi.spyOn(openAICodexModule, "loginOpenAICodex").mockResolvedValue(CREDENTIALS);
+
+		await authStorage.login("openai-codex-browser", { onAuth: () => {}, onPrompt: async () => "" });
+
+		expect(login).toHaveBeenCalledWith(expect.objectContaining({ method: "browser" }));
+		expect(store.listAuthCredentials("openai-codex")).toHaveLength(1);
+		expect(store.listAuthCredentials("openai-codex-browser")).toHaveLength(0);
+		expect(authStorage.hasAuth("openai-codex-browser")).toBe(true);
+	});
+});

--- a/packages/ai/test/openai-codex-oauth.test.ts
+++ b/packages/ai/test/openai-codex-oauth.test.ts
@@ -167,4 +167,31 @@ describe("OpenAI Codex device OAuth", () => {
 		expect(sleepDurations).toEqual([6_000]);
 		expect(pollCount).toBe(2);
 	});
+
+	it("distinguishes denial and expiry while redacting server detail", async () => {
+		for (const testCase of [
+			{ error: "authorization_declined", expected: "Device authorization denied" },
+			{ error: "expired_token", expected: "Device authorization expired" },
+		]) {
+			const fetchImpl = (async (input: string | URL | Request) => {
+				const url = String(input);
+				if (url.endsWith("/deviceauth/usercode")) {
+					return Response.json({ device_auth_id: "device-id", user_code: "ABCD-EFGH", interval: "1" });
+				}
+				return Response.json(
+					{
+						error: testCase.error,
+						error_description:
+							"request rejected at https://auth.openai.com/codex/device?token=server-secret Bearer bearer-secret",
+					},
+					{ status: 401 },
+				);
+			}) as typeof fetch;
+
+			const result = loginOpenAICodexDevice({}, { fetch: fetchImpl, sleep: async () => {} });
+			await expect(result).rejects.toThrow(testCase.expected);
+			await expect(result).rejects.not.toThrow("server-secret");
+			await expect(result).rejects.not.toThrow("bearer-secret");
+		}
+	});
 });

--- a/packages/ai/test/openai-codex-oauth.test.ts
+++ b/packages/ai/test/openai-codex-oauth.test.ts
@@ -4,6 +4,7 @@ import {
 	formatOpenAICodexTokenEndpointError,
 	loginOpenAICodex,
 	loginOpenAICodexDevice,
+	resolveOpenAICodexLoginMethod,
 	shouldUseOpenAICodexDeviceFlow,
 } from "../src/utils/oauth/openai-codex";
 
@@ -40,6 +41,7 @@ describe("OpenAI Codex browser OAuth", () => {
 
 		await expect(
 			loginOpenAICodex({
+				method: "browser",
 				onAuth: vi.fn(),
 				onPrompt: async () => "",
 			}),
@@ -72,6 +74,10 @@ describe("OpenAI Codex login method", () => {
 		expect(shouldUseOpenAICodexDeviceFlow({ SSH_CONNECTION: "client server" }, "linux", true)).toBe(true);
 		expect(shouldUseOpenAICodexDeviceFlow({ SSH_TTY: "/dev/pts/1" }, "linux", true)).toBe(true);
 		expect(shouldUseOpenAICodexDeviceFlow({}, "darwin", true)).toBe(false);
+		expect(resolveOpenAICodexLoginMethod("auto", { SSH_CONNECTION: "client server" }, "linux", true)).toBe("device");
+		expect(resolveOpenAICodexLoginMethod("browser", { SSH_CONNECTION: "client server" }, "linux", true)).toBe(
+			"browser",
+		);
 	});
 });
 

--- a/packages/ai/test/openai-codex-oauth.test.ts
+++ b/packages/ai/test/openai-codex-oauth.test.ts
@@ -3,6 +3,7 @@ import {
 	createOpenAICodexAuthorizationUrl,
 	formatOpenAICodexTokenEndpointError,
 	loginOpenAICodex,
+	loginOpenAICodexDevice,
 	shouldUseOpenAICodexDeviceFlow,
 } from "../src/utils/oauth/openai-codex";
 
@@ -71,5 +72,65 @@ describe("OpenAI Codex login method", () => {
 		expect(shouldUseOpenAICodexDeviceFlow({ SSH_CONNECTION: "client server" }, "linux", true)).toBe(true);
 		expect(shouldUseOpenAICodexDeviceFlow({ SSH_TTY: "/dev/pts/1" }, "linux", true)).toBe(true);
 		expect(shouldUseOpenAICodexDeviceFlow({}, "darwin", true)).toBe(false);
+	});
+});
+
+describe("OpenAI Codex device OAuth", () => {
+	it("shows a short code, polls remotely, and returns normal Codex credentials without a callback listener", async () => {
+		const encodeJwtPart = (value: unknown) => Buffer.from(JSON.stringify(value)).toString("base64url");
+		const accessToken = `${encodeJwtPart({ alg: "none" })}.${encodeJwtPart({
+			"https://api.openai.com/auth": { chatgpt_account_id: "acct-device" },
+			"https://api.openai.com/profile": { email: "USER@example.com" },
+		})}.signature`;
+		const requests: Array<{ url: string; body: string }> = [];
+		let pollCount = 0;
+		const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+			const url = String(input);
+			requests.push({ url, body: String(init?.body ?? "") });
+			if (url.endsWith("/deviceauth/usercode")) {
+				return Response.json({ device_auth_id: "device-secret", user_code: "ABCD-EFGH", interval: "5" });
+			}
+			if (url.endsWith("/deviceauth/token")) {
+				pollCount += 1;
+				return pollCount === 1
+					? Response.json({ error: "authorization_pending" }, { status: 404 })
+					: Response.json({ authorization_code: "authorization-secret", code_verifier: "verifier-secret" });
+			}
+			if (url.endsWith("/oauth/token")) {
+				return Response.json({ access_token: accessToken, refresh_token: "refresh-secret", expires_in: 3600 });
+			}
+			throw new Error(`Unexpected request: ${url}`);
+		}) as typeof fetch;
+		const onAuth = vi.fn();
+		const progress: string[] = [];
+
+		const credentials = await loginOpenAICodexDevice(
+			{ onAuth, onProgress: message => progress.push(message) },
+			{ fetch: fetchImpl, sleep: async () => {} },
+		);
+
+		expect(onAuth).toHaveBeenCalledWith({
+			url: "https://auth.openai.com/codex/device",
+			instructions: "Enter this one-time code: ABCD-EFGH (expires in 15 minutes)",
+		});
+		expect(requests.map(request => request.url)).toEqual([
+			"https://auth.openai.com/api/accounts/deviceauth/usercode",
+			"https://auth.openai.com/api/accounts/deviceauth/token",
+			"https://auth.openai.com/api/accounts/deviceauth/token",
+			"https://auth.openai.com/oauth/token",
+		]);
+		expect(requests.some(request => request.url.includes("localhost:1455"))).toBe(false);
+		expect(requests[3]?.body).toContain("redirect_uri=https%3A%2F%2Fauth.openai.com%2Fdeviceauth%2Fcallback");
+		expect(credentials).toMatchObject({
+			access: accessToken,
+			refresh: "refresh-secret",
+			accountId: "acct-device",
+			email: "user@example.com",
+		});
+		const visibleProgress = progress.join("\n");
+		expect(visibleProgress).not.toContain("device-secret");
+		expect(visibleProgress).not.toContain("authorization-secret");
+		expect(visibleProgress).not.toContain("verifier-secret");
+		expect(visibleProgress).not.toContain("refresh-secret");
 	});
 });

--- a/packages/ai/test/openai-codex-oauth.test.ts
+++ b/packages/ai/test/openai-codex-oauth.test.ts
@@ -133,4 +133,38 @@ describe("OpenAI Codex device OAuth", () => {
 		expect(visibleProgress).not.toContain("verifier-secret");
 		expect(visibleProgress).not.toContain("refresh-secret");
 	});
+
+	it("backs off when the device endpoint asks the client to slow down", async () => {
+		const accessToken = `${Buffer.from("{}").toString("base64url")}.${Buffer.from(
+			JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: "acct-slow" } }),
+		).toString("base64url")}.signature`;
+		let pollCount = 0;
+		const sleepDurations: number[] = [];
+		const fetchImpl = (async (input: string | URL | Request) => {
+			const url = String(input);
+			if (url.endsWith("/deviceauth/usercode")) {
+				return Response.json({ device_auth_id: "device-id", user_code: "SLOW-DOWN", interval: "1" });
+			}
+			if (url.endsWith("/deviceauth/token")) {
+				pollCount += 1;
+				return pollCount === 1
+					? Response.json({ error: "slow_down", error_description: "poll less often" }, { status: 429 })
+					: Response.json({ authorization_code: "code", code_verifier: "verifier" });
+			}
+			return Response.json({ access_token: accessToken, refresh_token: "refresh", expires_in: 3600 });
+		}) as typeof fetch;
+
+		await loginOpenAICodexDevice(
+			{},
+			{
+				fetch: fetchImpl,
+				sleep: async milliseconds => {
+					sleepDurations.push(milliseconds);
+				},
+			},
+		);
+
+		expect(sleepDurations).toEqual([6_000]);
+		expect(pollCount).toBe(2);
+	});
 });

--- a/packages/ai/test/openai-codex-oauth.test.ts
+++ b/packages/ai/test/openai-codex-oauth.test.ts
@@ -194,4 +194,15 @@ describe("OpenAI Codex device OAuth", () => {
 			await expect(result).rejects.not.toThrow("bearer-secret");
 		}
 	});
+
+	it("cancels before making a device authorization request", async () => {
+		const abortController = new AbortController();
+		abortController.abort();
+		const fetchImpl = vi.fn(async () => Response.json({})) as unknown as typeof fetch;
+
+		await expect(loginOpenAICodexDevice({ signal: abortController.signal }, { fetch: fetchImpl })).rejects.toThrow(
+			"Device authorization cancelled",
+		);
+		expect(fetchImpl).not.toHaveBeenCalled();
+	});
 });

--- a/packages/ai/test/openai-codex-oauth.test.ts
+++ b/packages/ai/test/openai-codex-oauth.test.ts
@@ -57,7 +57,7 @@ describe("OpenAI Codex browser OAuth", () => {
 			JSON.stringify({
 				error: "invalid_grant",
 				error_description:
-					"authorization expired; retry https://localhost/callback?code=secret-code&state=secret-state access_token=secret-token",
+					"authorization expired; retry https://localhost/callback?code=secret-code&state=secret-state access_token=secret-token code_verifier=secret-verifier device_auth_id=secret-device",
 			}),
 		);
 
@@ -65,6 +65,8 @@ describe("OpenAI Codex browser OAuth", () => {
 		expect(detail).not.toContain("secret-code");
 		expect(detail).not.toContain("secret-state");
 		expect(detail).not.toContain("secret-token");
+		expect(detail).not.toContain("secret-verifier");
+		expect(detail).not.toContain("secret-device");
 		expect(detail).toContain("[REDACTED]");
 	});
 });

--- a/packages/ai/test/openai-codex-oauth.test.ts
+++ b/packages/ai/test/openai-codex-oauth.test.ts
@@ -211,4 +211,12 @@ describe("OpenAI Codex device OAuth", () => {
 		);
 		expect(fetchImpl).not.toHaveBeenCalled();
 	});
+
+	it("explains when device login is disabled for the ChatGPT account or workspace", async () => {
+		const fetchImpl = vi.fn(async () => new Response("Not Found", { status: 404 })) as unknown as typeof fetch;
+
+		await expect(loginOpenAICodexDevice({}, { fetch: fetchImpl })).rejects.toThrow(
+			"Device-code login is not enabled for this ChatGPT account or workspace",
+		);
+	});
 });

--- a/packages/ai/test/openai-codex-oauth.test.ts
+++ b/packages/ai/test/openai-codex-oauth.test.ts
@@ -3,6 +3,7 @@ import {
 	createOpenAICodexAuthorizationUrl,
 	formatOpenAICodexTokenEndpointError,
 	loginOpenAICodex,
+	shouldUseOpenAICodexDeviceFlow,
 } from "../src/utils/oauth/openai-codex";
 
 afterEach(() => {
@@ -62,5 +63,13 @@ describe("OpenAI Codex browser OAuth", () => {
 		expect(detail).not.toContain("secret-state");
 		expect(detail).not.toContain("secret-token");
 		expect(detail).toContain("[REDACTED]");
+	});
+});
+
+describe("OpenAI Codex login method", () => {
+	it("defaults SSH sessions to device authorization without treating local terminals as remote", () => {
+		expect(shouldUseOpenAICodexDeviceFlow({ SSH_CONNECTION: "client server" }, "linux", true)).toBe(true);
+		expect(shouldUseOpenAICodexDeviceFlow({ SSH_TTY: "/dev/pts/1" }, "linux", true)).toBe(true);
+		expect(shouldUseOpenAICodexDeviceFlow({}, "darwin", true)).toBe(false);
 	});
 });

--- a/packages/coding-agent/scripts/openai-subscription-uat.ts
+++ b/packages/coding-agent/scripts/openai-subscription-uat.ts
@@ -73,7 +73,7 @@ export function redactSensitiveOutput(value: string): string {
 		)
 		.replace(/\bBearer\s+[^\s,;]+/gi, "Bearer [REDACTED]")
 		.replace(
-			/\b(access_token|refresh_token|id_token|authorization_code|code|token|state)\b(\s*[:=]\s*)(?:"[^"]*"|'[^']*'|[^\s,;]+)/gi,
+			/\b(access_token|refresh_token|id_token|authorization_code|code_verifier|device_auth_id|user_code|code|token|state)\b(\s*[:=]\s*)(?:"[^"]*"|'[^']*'|[^\s,;]+)/gi,
 			"$1$2[REDACTED]",
 		)
 		.replace(/\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g, "[REDACTED]");
@@ -123,6 +123,7 @@ function freshEnvironment(stateDir: string): Record<string, string> {
 		XDG_DATA_HOME: path.join(stateDir, "data"),
 		XDG_STATE_HOME: path.join(stateDir, "state"),
 		TERM: "xterm-256color",
+		SSH_CONNECTION: "uat-client uat-server",
 		PATH: Bun.env.PATH ?? "/usr/local/bin:/usr/bin:/bin",
 	};
 	for (const name of [
@@ -185,6 +186,7 @@ async function runFreshOAuthRoundTrip(target: UatTarget): Promise<void> {
 		const startup = visibleTranscript(transcript);
 		for (const provider of [
 			"ChatGPT Plus/Pro (Codex Subscription)",
+			"ChatGPT Plus/Pro (Browser callback)",
 			"OpenAI Responses API (usage-based API access)",
 		]) {
 			if (!startup.includes(provider)) throw new Error(`${target.label} did not list ${provider}`);
@@ -197,7 +199,7 @@ async function runFreshOAuthRoundTrip(target: UatTarget): Promise<void> {
 		await waitFor(
 			target.label,
 			() => transcript,
-			visible => visible.includes("ChatGPT Plus/Pro (Codex Subscription)") && visible.includes("1 match"),
+			visible => visible.includes("ChatGPT Plus/Pro (Codex Subscription)") && visible.includes("2 matches"),
 			"the filtered ChatGPT provider",
 			() => exited,
 			STARTUP_TIMEOUT_MS,
@@ -206,8 +208,9 @@ async function runFreshOAuthRoundTrip(target: UatTarget): Promise<void> {
 		await waitFor(
 			target.label,
 			() => transcript,
-			visible => visible.includes("https://auth.openai.com/oauth/authorize?"),
-			"the ChatGPT browser authorization request",
+			visible =>
+				visible.includes("https://auth.openai.com/codex/device") && visible.includes("Enter this one-time code:"),
+			"the ChatGPT device authorization code",
 			() => exited,
 			STARTUP_TIMEOUT_MS,
 		);

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1,7 +1,13 @@
 import * as os from "node:os";
 import * as path from "node:path";
 import { ThinkingLevel } from "@f5-sales-demo/pi-agent-core";
-import { getOAuthProviders, loginLiteLLM, type OAuthPrompt, type OAuthProvider } from "@f5-sales-demo/pi-ai";
+import {
+	getOAuthProviders,
+	loginLiteLLM,
+	type OAuthPrompt,
+	type OAuthProvider,
+	resolveOpenAICodexLoginMethod,
+} from "@f5-sales-demo/pi-ai";
 import type { Component } from "@f5-sales-demo/pi-tui";
 import { Loader, Spacer, Text } from "@f5-sales-demo/pi-tui";
 import { getAgentDbPath, getAgentDir, getConfigDirName, getProjectDir } from "@f5-sales-demo/pi-utils";
@@ -70,7 +76,7 @@ import {
 
 const CALLBACK_SERVER_PROVIDERS = new Set<OAuthProvider>([
 	"anthropic",
-	"openai-codex",
+	"openai-codex-browser",
 	"gitlab-duo",
 	"google-gemini-cli",
 	"google-antigravity",
@@ -1063,7 +1069,9 @@ export class SelectorController {
 
 		this.ctx.showStatus(`Logging in to ${providerId}…`);
 		const manualInput = this.ctx.oauthManualInput;
-		const useManualInput = CALLBACK_SERVER_PROVIDERS.has(providerId as OAuthProvider);
+		const useManualInput =
+			CALLBACK_SERVER_PROVIDERS.has(providerId as OAuthProvider) ||
+			(providerId === "openai-codex" && resolveOpenAICodexLoginMethod() === "browser");
 		const loginCallbacks = {
 			onAuth: (info: { url: string; instructions?: string }) => {
 				this.ctx.chatContainer.addChild(new Spacer(1));

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1072,6 +1072,7 @@ export class SelectorController {
 		const useManualInput =
 			CALLBACK_SERVER_PROVIDERS.has(providerId as OAuthProvider) ||
 			(providerId === "openai-codex" && resolveOpenAICodexLoginMethod() === "browser");
+		const shouldOpenBrowser = providerId !== "openai-codex" || resolveOpenAICodexLoginMethod() === "browser";
 		const loginCallbacks = {
 			onAuth: (info: { url: string; instructions?: string }) => {
 				this.ctx.chatContainer.addChild(new Spacer(1));
@@ -1087,7 +1088,7 @@ export class SelectorController {
 					this.ctx.chatContainer.addChild(new Text(theme.fg("dim", MANUAL_LOGIN_TIP), 1, 0));
 				}
 				this.ctx.ui.requestRender();
-				this.ctx.openInBrowser(info.url);
+				if (shouldOpenBrowser) this.ctx.openInBrowser(info.url);
 			},
 			onPrompt: async (prompt: OAuthPrompt) => {
 				this.ctx.chatContainer.addChild(new Spacer(1));

--- a/packages/coding-agent/test/modes/controllers/selector-controller-oauth-login.test.ts
+++ b/packages/coding-agent/test/modes/controllers/selector-controller-oauth-login.test.ts
@@ -64,3 +64,40 @@ describe("SelectorController Google Antigravity login", () => {
 		expect(rendered).toContain("Default model: google-antigravity/gemini-3.6-flash-high");
 	});
 });
+
+describe("SelectorController ChatGPT device login", () => {
+	it("does not try to open a browser on the remote Ubuntu host", async () => {
+		const previousSshConnection = process.env.SSH_CONNECTION;
+		process.env.SSH_CONNECTION = "client server";
+		try {
+			const openInBrowser = vi.fn();
+			const login = vi.fn(async (_provider, callbacks) => {
+				callbacks.onAuth({
+					url: "https://auth.openai.com/codex/device",
+					instructions: "Enter this one-time code: ABCD-EFGH",
+				});
+			});
+			const ctx = {
+				session: {
+					modelRegistry: { authStorage: { login }, refresh: vi.fn(async () => undefined), getAll: () => [] },
+				},
+				oauthManualInput: new OAuthManualInputManager(),
+				statusLine: { invalidate: vi.fn() },
+				updateEditorBorderColor: vi.fn(),
+				chatContainer: { addChild: vi.fn() },
+				ui: { requestRender: vi.fn() },
+				showStatus: vi.fn(),
+				showError: vi.fn(),
+				openInBrowser,
+			} as unknown as InteractiveModeContext;
+
+			await new SelectorController(ctx).showOAuthSelector("login", "openai-codex");
+
+			expect(login).toHaveBeenCalledTimes(1);
+			expect(openInBrowser).not.toHaveBeenCalled();
+		} finally {
+			if (previousSshConnection === undefined) delete process.env.SSH_CONNECTION;
+			else process.env.SSH_CONNECTION = previousSshConnection;
+		}
+	});
+});

--- a/packages/coding-agent/test/oauth-selector-search.test.ts
+++ b/packages/coding-agent/test/oauth-selector-search.test.ts
@@ -23,6 +23,14 @@ function renderText(selector: OAuthSelectorComponent): string {
 }
 
 describe("OAuthSelectorComponent provider search", () => {
+	it("offers an explicit browser-callback login alongside automatic ChatGPT login", () => {
+		expect(getOAuthProviders().find(provider => provider.id === "openai-codex-browser")).toMatchObject({
+			name: "ChatGPT Plus/Pro (Browser callback)",
+			canonicalId: "openai-codex",
+			loginOnly: true,
+		});
+	});
+
 	it("renders a bounded provider viewport with position and input guidance", () => {
 		const { selector } = createSelector();
 		const providerCount = getOAuthProviders().length;
@@ -41,8 +49,9 @@ describe("OAuthSelectorComponent provider search", () => {
 
 		const rendered = renderText(selector);
 		expect(rendered).toContain("ChatGPT Plus/Pro (Codex Subscription)");
+		expect(rendered).toContain("ChatGPT Plus/Pro (Browser callback)");
 		expect(rendered).not.toContain("Anthropic (Claude Pro/Max)");
-		expect(rendered).toContain(`1 match (${getOAuthProviders().length} total)`);
+		expect(rendered).toContain(`2 matches (${getOAuthProviders().length} total)`);
 
 		selector.handleInput("\n");
 		expect(onSelect).toHaveBeenCalledWith("openai-codex");
@@ -75,7 +84,7 @@ describe("OAuthSelectorComponent provider search", () => {
 		for (let index = 0; index < 11; index += 1) selector.handleInput("\x1b[B");
 
 		const rendered = renderText(selector);
-		expect(rendered).toContain("Antigravity (Gemini 3, Claude, GPT-OSS)");
+		expect(rendered).toContain("Google Cloud Code Assist (Gemini CLI)");
 		expect(rendered).not.toContain("Anthropic (Claude Pro/Max)");
 		expect(rendered).toContain(`Showing 3-12 of ${getOAuthProviders().length}`);
 	});
@@ -90,6 +99,8 @@ describe("OAuthSelectorComponent provider search", () => {
 		const rendered = renderText(logout);
 		expect(rendered).toContain("Antigravity (Gemini 3, Claude, GPT-OSS)");
 		expect(rendered).not.toContain("Google Antigravity Enterprise (Gemini 3.6 Flash High)");
-		expect(rendered).toContain(`1 match (${getOAuthProviders().length - 1} total)`);
+		expect(rendered).toContain(
+			`1 match (${getOAuthProviders().filter(provider => !provider.loginOnly).length} total)`,
+		);
 	});
 });

--- a/packages/coding-agent/test/openai-subscription-uat.test.ts
+++ b/packages/coding-agent/test/openai-subscription-uat.test.ts
@@ -9,6 +9,9 @@ describe("OpenAI subscription source UAT", () => {
 		expect(source).not.toContain('"codex", ["login", "status"]');
 		expect(source).not.toContain('"codex", [');
 		expect(source).not.toContain('"openai/gpt-5-mini"');
+		expect(source).toContain('visible.includes("https://auth.openai.com/codex/device")');
+		expect(source).toContain('SSH_CONNECTION: "uat-client uat-server"');
+		expect(source).not.toContain('"the ChatGPT browser authorization request"');
 	});
 
 	it("redacts OAuth query strings, tokens, and sensitive headers from diagnostics", () => {


### PR DESCRIPTION
## What

- prefer ChatGPT device authorization in SSH and headless Linux sessions
- show a one-time code for entry at the standard ChatGPT device page, without a localhost callback, tunnel, or remote browser launch
- retain an explicit browser-callback choice for local use and accounts where device login is disabled
- store both flows under the canonical `openai-codex` provider and preserve Terra post-login selection and routing
- document the two login paths and extend the isolated subscription UAT

## Why

The restored ChatGPT OAuth flow used a fixed localhost callback. When xcsh runs on an Ubuntu workstation reached from a managed Mac over SSH, that callback belongs to the remote host and creates an unnecessary dependency on tunneling or client-side setup. OpenAI device authorization is the appropriate callback-free path for this environment.

Closes #3236

## Testing

- `bun run check:ts`
- `bun test --cwd packages/ai --max-concurrency 2`
- `bun test --cwd packages/coding-agent --max-concurrency 2` (6,637 pass, 559 skip, 0 fail)
- `bash scripts/install-tests/run-ci.sh` (binary, source-ref, tarball, and platform package smoke tests)
- `bun run test` (workspace suites green; coding-agent 6,637 pass, 559 skip, 0 fail)
- live preserved-account `openai-codex/gpt-5.6-terra` medium sentinel returned exactly `XCSH_DEVICE_CODE_TERRA_OK` without credential inspection

---

- [x] `bun run check:ts` passes
- [x] `bun run test` passes with zero failures
- [x] English provider documentation updated
- [x] Issue linked via `Closes #3236`