### PR TITLE
test(coding-agent): prove deterministic map semantics

### DIFF
--- a/packages/coding-agent/test/render-map.test.ts
+++ b/packages/coding-agent/test/render-map.test.ts
@@ -34,6 +34,16 @@ const location = {
 	sources: [source],
 };
 
+function expectDeterministicMapSemantics(svg: string): void {
+	expect(svg).toContain('class="title">Current edges</text>');
+	expect(svg).toContain('class="marker">1</text>');
+	expect(svg).toContain('class="label">Toronto edge</text>');
+	expect(svg).toContain('<g class="legend">');
+	expect(svg).toContain("approximate / inferred");
+	expect(svg).toContain('class="attribution">Schematic Web Mercator • no basemap tiles</text>');
+	expect(svg).not.toContain("Unresolved edge");
+}
+
 describe("MapLocationV1", () => {
 	test("rejects coordinates without current-request provenance", () => {
 		expect(() => validateMapLocationV1({ ...location, sources: [] })).toThrow("provenance");
@@ -61,11 +71,19 @@ describe("MapLocationV1", () => {
 
 	test("builds deterministic schematic output with visible attribution and styling", () => {
 		const value = validateMapLocationV1(location);
-		const first = buildMapSvg("Current edges", [value], "schematic");
-		const second = buildMapSvg("Current edges", [value], "schematic");
+		const unresolved = validateMapLocationV1({
+			id: "unresolved-edge",
+			label: "Unresolved edge",
+			precision: "unresolved",
+			resolution: "unresolved",
+			confidence: "unknown",
+			sources: [source],
+		});
+		const first = buildMapSvg("Current edges", [value, unresolved], "schematic");
+		const second = buildMapSvg("Current edges", [value, unresolved], "schematic");
 		expect(first).toBe(second);
-		expect(first).toContain("Schematic Web Mercator");
-		expect(first).toContain("approximate / inferred");
+		expectDeterministicMapSemantics(first);
+		expect(() => expectDeterministicMapSemantics(first.replace("Toronto edge", ""))).toThrow();
 	});
 });
 


### PR DESCRIPTION
## What

Strengthen the hermetic schematic map test to prove deterministic semantic content: title, representative label, plotted marker, legend, attribution, and unresolved-location filtering. The sensitivity assertion demonstrates that removing a representative label fails the semantic contract.

## Why

This supplies the renderer-side layer of proof required by f5-sales-demo/marketplace#1195 without a brittle live pixel golden or production renderer change.

## Testing

- `bun run test` baseline: coding-agent 6,637 pass / 559 skip / 0 fail; all other workspaces 0 fail
- `bun test packages/coding-agent/test/render-map.test.ts --max-concurrency 2`: 6 pass / 0 fail / 24 assertions
- `bun run check:ts`: passed across all workspaces

Closes #3239

- [x] `bun run check:ts` passes
- [x] Targeted renderer tests pass with zero failures
- [x] Issue linked via `Closes #3239`
- [x] Test-only; no CHANGELOG or translation update required