### PR TITLE
fix(coding-agent): restore compatible update routing

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,12 @@
   contract so TUI, Browser, Office, RPC, and ACP transports no longer identify media by tool name
   ([#3202](https://github.com/f5-sales-demo/xcsh/issues/3202)).
 
+### Fixed
+
+- Restored bare `xcsh update` as a backward-compatible executable updater while preserving
+  manifest-based resource updates and the explicit `xcsh self-update` command
+  ([#3249](https://github.com/f5-sales-demo/xcsh/issues/3249)).
+
 ## [20.6.3] - 2026-08-07
 
 ### Improved

--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -1,7 +1,7 @@
 /**
  * Update CLI command handler.
  *
- * Handles `xcsh self-update` to check for and install executable updates.
+ * Handles executable updates for explicit `xcsh self-update` and compatible `xcsh update` forms.
  * Auto-detects the installation method (npm, brew, bun, or standalone binary)
  * and updates through the appropriate channel.
  */
@@ -439,14 +439,21 @@ export async function runUpdateCommand(opts: { force: boolean; check: boolean })
  * Print update command help.
  */
 export function printUpdateHelp(): void {
-	console.log(`${chalk.bold(`${APP_NAME} update`)} - Check for and install updates
+	console.log(`${chalk.bold(`${APP_NAME} update`)} - Update the executable or existing resources from manifests
 
 ${chalk.bold("Usage:")}
-  ${APP_NAME} update [options]
+  ${APP_NAME} update [--check | --force]
+  ${APP_NAME} update -f <manifest> [resource options]
 
-${chalk.bold("Options:")}
-  -c, --check   Check for updates without installing
-  -f, --force   Force reinstall even if up to date
+${chalk.bold("Executable options:")}
+  -c, --check   Check for executable updates without installing
+      --force   Force reinstall even if up to date
+
+${chalk.bold("Resource input:")}
+  -f, --filename <manifest>   Update resources from a manifest
+
+Short -f means --filename for xcsh update. Use xcsh self-update -f for the
+short executable force form. Executable and resource flags cannot be mixed.
 
 ${chalk.bold("Install methods (auto-detected):")}
   npm           Installed via npm install -g
@@ -458,5 +465,6 @@ ${chalk.bold("Examples:")}
   ${APP_NAME} update           Update to latest version
   ${APP_NAME} update --check   Check if updates are available
   ${APP_NAME} update --force   Force reinstall
+  ${APP_NAME} update -f manifest.yaml   Update resources
 `);
 }

--- a/packages/coding-agent/src/commands/update.ts
+++ b/packages/coding-agent/src/commands/update.ts
@@ -1,21 +1,111 @@
-import { Command } from "@f5-sales-demo/pi-utils/cli";
+import { CliUsageError, Command, Flags, parseCommandArgv } from "@f5-sales-demo/pi-utils/cli";
 import { runResourceCli } from "../cli/resource-cli";
+import { runUpdateCommand } from "../cli/update-cli";
+import { initTheme } from "../modes/theme/theme";
 import { manifestResourceFlags } from "./resource-flags";
 
+const updateFlags = {
+	...manifestResourceFlags,
+	force: Flags.boolean({
+		description: "Force executable update (short -f is reserved for resource manifests)",
+		default: false,
+	}),
+	check: Flags.boolean({ char: "c", description: "Check for executable updates without installing", default: false }),
+};
+
+type ResourceOutputFormat = "json" | "yaml" | "table" | "wide";
+
+export type UpdateInvocation =
+	| { mode: "executable"; force: boolean; check: boolean }
+	| {
+			mode: "resource";
+			filenames: string[] | undefined;
+			namespace: string | undefined;
+			outputFormat: ResourceOutputFormat;
+			recursive: boolean;
+			dryRun: "client" | undefined;
+			resultFile: string | undefined;
+	  };
+
+function explicitlyRequestsDefaultOutput(argv: readonly string[]): boolean {
+	return argv.some(arg => arg === "--output" || arg.startsWith("--output=") || arg === "-o");
+}
+
+/** Resolve the backward-compatible `update` command before either updater can perform I/O. */
+export function parseUpdateInvocation(argv: readonly string[]): UpdateInvocation {
+	if (argv.length === 1 && argv[0] === "-f") {
+		throw new CliUsageError(
+			"Ambiguous -f: use 'xcsh update --force' or 'xcsh self-update -f' for executable updates; otherwise provide a resource manifest",
+		);
+	}
+	const parsed = parseCommandArgv(argv, { flags: updateFlags });
+	if (parsed.argv.length > 0) {
+		throw new CliUsageError(`Unexpected argument${parsed.argv.length === 1 ? "" : "s"}: ${parsed.argv.join(" ")}`);
+	}
+
+	const flags = parsed.flags as {
+		filename?: string[];
+		namespace?: string;
+		output: ResourceOutputFormat;
+		recursive: boolean;
+		"dry-run"?: "client";
+		"result-file"?: string;
+		force: boolean;
+		check: boolean;
+	};
+	const executableRequested = flags.force || flags.check;
+	const resourceRequested =
+		flags.filename !== undefined ||
+		flags.namespace !== undefined ||
+		flags.recursive ||
+		flags["dry-run"] !== undefined ||
+		flags["result-file"] !== undefined ||
+		flags.output !== "table" ||
+		explicitlyRequestsDefaultOutput(argv);
+
+	if (executableRequested && resourceRequested) {
+		throw new CliUsageError("update cannot combine executable-update and resource-update flags");
+	}
+	if (!resourceRequested) {
+		return { mode: "executable", force: flags.force, check: flags.check };
+	}
+	return {
+		mode: "resource",
+		filenames: flags.filename,
+		namespace: flags.namespace,
+		outputFormat: flags.output,
+		recursive: flags.recursive,
+		dryRun: flags["dry-run"],
+		resultFile: flags["result-file"],
+	};
+}
+
 export default class Update extends Command {
-	static description = "Update existing resources from manifests";
-	static flags = manifestResourceFlags;
+	static description = "Update the xcsh executable or existing resources from manifests";
+	static flags = updateFlags;
+	static examples = [
+		"xcsh update                         # update the executable",
+		"xcsh update --check                 # check the executable version",
+		"xcsh update --force                 # force an executable reinstall",
+		"xcsh self-update -f                 # short force form for the executable",
+		"xcsh update -f manifest.yaml        # update resources from a manifest",
+	];
 
 	async run(): Promise<void> {
-		const { flags } = await this.parse(Update);
+		const invocation = parseUpdateInvocation(this.argv);
+		if (invocation.mode === "executable") {
+			await initTheme();
+			await runUpdateCommand({ force: invocation.force, check: invocation.check });
+			return;
+		}
 		await runResourceCli({
 			operation: "update",
-			filenames: flags.filename,
-			namespace: flags.namespace,
-			outputFormat: flags.output as "json" | "yaml" | "table" | "wide",
-			recursive: flags.recursive,
-			dryRun: flags["dry-run"] as "client" | undefined,
-			resultFile: flags["result-file"],
+			filenames: invocation.filenames,
+			namespace: invocation.namespace,
+			outputFormat: invocation.outputFormat,
+			recursive: invocation.recursive,
+			dryRun: invocation.dryRun,
+			resultFile: invocation.resultFile,
 		});
 	}
 }

--- a/packages/coding-agent/src/locales/en.json
+++ b/packages/coding-agent/src/locales/en.json
@@ -288,7 +288,7 @@
 	"welcome.modelProvider": "Model Provider",
 	"welcome.plugins": "Plugins",
 	"welcome.pluginSetupHint": "run: /plugin setup",
-	"welcome.updateHint": "run: xcsh self-update",
+	"welcome.updateHint": "run: xcsh update",
 	"welcome.newVersion": "new version",
 	"welcome.connectionFailed": "— connection failed",
 	"welcome.runLoginReconnect": "Run /login to reconnect",

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -180,7 +180,7 @@ async function runInteractiveMode(
 	if (settings.get("startup.checkUpdate")) {
 		void versionCheckPromise
 			.then(latest => {
-				if (latest) mode.showStatus(`Update available: v${latest} — run: xcsh self-update`, { dim: true });
+				if (latest) mode.showStatus(`Update available: v${latest} — run: xcsh update`, { dim: true });
 			})
 			.catch(() => {});
 	}

--- a/packages/coding-agent/test/fixtures/update-fetch-preload.ts
+++ b/packages/coding-agent/test/fixtures/update-fetch-preload.ts
@@ -1,0 +1,18 @@
+import * as fs from "node:fs";
+import packageJson from "../../package.json";
+
+const version = packageJson.version;
+
+globalThis.fetch = (async (input: string | URL | Request) => {
+	const marker = process.env.XCSH_UPDATE_FETCH_MARKER;
+	if (marker) fs.writeFileSync(marker, "fetch called\n");
+
+	const url = String(input);
+	if (url === "https://registry.npmjs.org/@f5-sales-demo/xcsh/latest") {
+		return Response.json({ version });
+	}
+	if (url.includes("/releases/download/") && url.includes("/xcsh-")) {
+		return new Response(`#!/bin/sh\nprintf 'xcsh/${version}\\n'\n`, { status: 200 });
+	}
+	throw new Error(`Unexpected update test URL: ${url}`);
+}) as typeof fetch;

--- a/packages/coding-agent/test/update-cli.test.ts
+++ b/packages/coding-agent/test/update-cli.test.ts
@@ -5,29 +5,85 @@ import * as path from "node:path";
 import { renderCommandHelp } from "@f5-sales-demo/pi-utils/cli";
 import { _resolveUpdateMethodForTest, parseUpdateArgs } from "../src/cli/update-cli";
 import SelfUpdate from "../src/commands/self-update";
-import Update from "../src/commands/update";
+import Update, { parseUpdateInvocation } from "../src/commands/update";
+
+const codingAgentDir = import.meta.dir.replace(/\/test$/, "");
+const updateFetchPreload = path.join(import.meta.dir, "fixtures", "update-fetch-preload.ts");
+
+function runUpdateSubprocess(args: string[], pathValue?: string): ReturnType<typeof Bun.spawnSync> {
+	return Bun.spawnSync([process.execPath, "--preload", updateFetchPreload, "src/cli.ts", "update", ...args], {
+		cwd: codingAgentDir,
+		env: { ...process.env, PATH: pathValue ?? process.env.PATH },
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+}
+
+function processOutput(result: ReturnType<typeof Bun.spawnSync>): { stdout: string; combined: string } {
+	const stdout = result.stdout?.toString() ?? "";
+	return { stdout, combined: `${stdout}${result.stderr?.toString() ?? ""}` };
+}
 
 describe("update command boundary", () => {
-	it("recognizes only self-update as the executable updater", () => {
+	it("keeps self-update as the explicit executable updater", () => {
 		expect(parseUpdateArgs(["self-update", "--check"])).toEqual({ force: false, check: true });
 		expect(parseUpdateArgs(["self-update", "--force"])).toEqual({ force: true, check: false });
 	});
 
-	it("never interprets manifest update flags as executable updater flags", () => {
-		expect(parseUpdateArgs(["update", "-f", "manifest.yaml"])).toBeUndefined();
+	it.each([
+		["bare", [], { force: false, check: false }],
+		["long check", ["--check"], { force: false, check: true }],
+		["short check", ["-c"], { force: false, check: true }],
+		["force", ["--force"], { force: true, check: false }],
+	] as const)("routes %s update to executable updating", (_name, argv, expected) => {
+		expect(parseUpdateInvocation([...argv])).toEqual({ mode: "executable", ...expected });
 	});
 
-	it("exposes distinct public CLI contracts for update and self-update", () => {
+	it.each([
+		["short filename", ["-f", "manifest.yaml"]],
+		["filename", ["--filename", "manifest.yaml"]],
+		["inline filename", ["--filename=manifest.yaml"]],
+		["namespace", ["--namespace", "demo"]],
+		["short namespace", ["-n", "demo"]],
+		["output", ["--output", "json"]],
+		["short output", ["-o", "yaml"]],
+		["recursive", ["--recursive"]],
+		["short recursive", ["-R"]],
+		["dry run", ["--dry-run", "client"]],
+		["result file", ["--result-file", "report.json"]],
+	] as const)("routes the %s manifest flag to resource updating", (_name, argv) => {
+		expect(parseUpdateInvocation([...argv])).toMatchObject({ mode: "resource" });
+	});
+
+	it.each([
+		[["--check", "-f", "manifest.yaml"]],
+		[["-c", "--namespace", "demo"]],
+		[["--force", "--dry-run", "client"]],
+	])("rejects mixed executable and resource flags before dispatch", argv => {
+		expect(() => parseUpdateInvocation(argv)).toThrow("cannot combine executable-update and resource-update flags");
+	});
+
+	it("rejects ambiguous, unknown, and positional update syntax as usage errors", () => {
+		expect(() => parseUpdateInvocation(["-f"])).toThrow(
+			"Ambiguous -f: use 'xcsh update --force' or 'xcsh self-update -f' for executable updates",
+		);
+		expect(() => parseUpdateInvocation(["--unknown"])).toThrow();
+		expect(() => parseUpdateInvocation(["manifest.yaml"])).toThrow();
+	});
+
+	it("documents both compatibility modes and the -f distinction", () => {
 		const write = vi.spyOn(process.stdout, "write").mockReturnValue(true);
 		try {
 			renderCommandHelp("xcsh", "update", Update);
-			const manifestUpdate = write.mock.calls.map(([chunk]) => String(chunk)).join("");
+			const compatibilityUpdate = write.mock.calls.map(([chunk]) => String(chunk)).join("");
 			write.mockClear();
 			renderCommandHelp("xcsh", "self-update", SelfUpdate);
 			const executableUpdate = write.mock.calls.map(([chunk]) => String(chunk)).join("");
 
-			expect(manifestUpdate).toContain("Update existing resources from manifests");
-			expect(manifestUpdate).toContain("--filename=<value>");
+			expect(compatibilityUpdate).toContain("Update the xcsh executable or existing resources from manifests");
+			expect(compatibilityUpdate).toContain("-f, --filename=<value>");
+			expect(compatibilityUpdate).toContain("--force");
+			expect(compatibilityUpdate).toContain("xcsh self-update -f");
 			expect(executableUpdate).toContain("Check for and install xcsh executable updates");
 			expect(executableUpdate).toContain("--check");
 		} finally {
@@ -35,16 +91,70 @@ describe("update command boundary", () => {
 		}
 	});
 
-	it("directs both English update notices to self-update", () => {
+	it("directs both English update notices to the version-universal command", () => {
 		const mainSource = fs.readFileSync(new URL("../src/main.ts", import.meta.url), "utf8");
 		const messages = JSON.parse(
 			fs.readFileSync(new URL("../src/locales/en.json", import.meta.url), "utf8"),
 		) as Record<string, string>;
 
-		expect(mainSource).toContain("run: xcsh self-update");
-		expect(mainSource).not.toContain("run: xcsh update`");
-		expect(messages["welcome.updateHint"]).toBe("run: xcsh self-update");
+		expect(mainSource).toContain("run: xcsh update");
+		expect(mainSource).not.toContain("run: xcsh self-update");
+		expect(messages["welcome.updateHint"]).toBe("run: xcsh update");
 	});
+
+	it.each([
+		["bare", []],
+		["check", ["--check"]],
+		["short check", ["-c"]],
+	])("runs the %s executable form without entering onboarding", (_name, argv) => {
+		const result = runUpdateSubprocess(argv);
+		const { combined: output } = processOutput(result);
+		expect(result.exitCode).toBe(0);
+		expect(output).toContain("Current version:");
+		expect(output).toContain("Already up to date");
+		expect(output).not.toContain("Model Provider URL");
+	});
+
+	it("runs update --force through executable replacement without entering onboarding", () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "xcsh-update-command-"));
+		const fakeBinary = path.join(tempDir, "xcsh");
+		try {
+			fs.writeFileSync(fakeBinary, "#!/bin/sh\nprintf 'xcsh/0.0.0\\n'\n", { mode: 0o755 });
+			const result = runUpdateSubprocess(["--force"], tempDir);
+			const { combined: output } = processOutput(result);
+			expect(result.exitCode).toBe(0);
+			expect(output).toContain("Forcing reinstall");
+			expect(output).toContain("Install method: binary");
+			expect(output).not.toContain("Model Provider URL");
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	}, 40_000);
+
+	it("returns usage exit 2 for mixed and invalid forms before fetching or resource output", () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "xcsh-update-rejection-"));
+		const fetchMarker = path.join(tempDir, "fetch-called");
+		try {
+			for (const argv of [["--check", "-f", "test/fixtures/resource-manifest.yaml"], ["-f"], ["--unknown"]]) {
+				const result = Bun.spawnSync(
+					[process.execPath, "--preload", updateFetchPreload, "src/cli.ts", "update", ...argv],
+					{
+						cwd: codingAgentDir,
+						env: { ...process.env, XCSH_UPDATE_FETCH_MARKER: fetchMarker },
+						stdout: "pipe",
+						stderr: "pipe",
+					},
+				);
+				const { stdout, combined: output } = processOutput(result);
+				expect(result.exitCode).toBe(2);
+				expect(stdout).not.toContain('"operation":"update"');
+				expect(output).not.toContain("Model Provider URL");
+				expect(fs.existsSync(fetchMarker)).toBe(false);
+			}
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	}, 40_000);
 });
 
 describe("update-cli install target detection", () => {


### PR DESCRIPTION
## Summary

Restore a version-universal executable update path without removing manifest-based resource
updates. Bare `xcsh update`, `--check` / `-c`, and `--force` now dispatch to the executable updater;
manifest flags retain resource handling; ambiguous or mixed forms fail with usage status before I/O.

## Related Issue

Closes #3249

## Changes

- Added deterministic compatibility dispatch and combined help for the two `update` modes.
- Preserved explicit `xcsh self-update`, resource flags, and resource-operation behavior.
- Restored English notices to `xcsh update` and recorded the fix in the Unreleased changelog.
- Added isolated routing, ambiguity, exit-code, help, notice, onboarding, and binary-replacement
  regressions while leaving managed locale files untouched.

## Verification evidence

- Red test: focused update/resource suite failed because `parseUpdateInvocation` did not exist.
- `bun test test/update-cli.test.ts test/resource-cli.test.ts --max-concurrency 1` — 41 passed,
  0 failed.
- `bun run check:ts` — all workspace Biome and TypeScript checks passed.
- `bun run ci:test:install-methods` — compiled binary, source-ref, tarball, sandbox, and platform
  package verification passed.
- `bun run test` — coding-agent 6,660 passed / 559 skipped / 0 failed; every other workspace passed
  with 0 failures.
- Built CLI UAT: combined `update --help`, manifest resource routing, and executable `update --check`
  passed; output contained no onboarding prompt.
- `bun run pii:gate -- --scope staged` — clean.

## Delivery evidence

- Feature branch: `fix/issue-3249-backward-compatible-updating`
- Commit: `880da68f4b`
- CI and auto-merge are being monitored through terminal `MERGED` state; cleanup and raw-main
  installation evidence will be recorded after merge.

## Checklist

- [x] Linked to a detailed issue with `Closes #N`
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above

- [ ] Pending, failed, behind, or conflicted states repaired through `MERGED`
- [ ] Worktree and confirmed-merged branch cleaned; fleet convergence confirmed when applicable
- [x] Follows project conventions and style guides
