### PR TITLE
fix(tui): recognize Herdr Kitty graphics capability

### DIFF
--- a/docs/en/configuration/herdr.md
+++ b/docs/en/configuration/herdr.md
@@ -5,6 +5,8 @@ description: Run xcsh conversations with isolated, conversation-owned support te
 
 xcsh can bind one conversation to one Herdr workspace and expose named support terminals as tabs. The recommended full rich-media stack is Ghostty with Kitty graphics, Herdr with `experimental.kitty_graphics=true`, and FFmpeg 6 or newer. Other terminals remain usable and receive static media fallbacks.
 
+When a released Herdr version exposes `HERDR_KITTY_GRAPHICS=1` alongside `HERDR_ENV=1`, xcsh uses the Kitty image protocol for TTY output even though Herdr deliberately reports `TERM=xterm-256color`. Both markers must be exactly `1`; their absence or any other value keeps images disabled for that generic terminal type. `PI_FORCE_IMAGE_PROTOCOL` remains authoritative. This contract requires the xcsh release containing this change and the corresponding future Herdr release; until then, the safe behavior is the text fallback. Restart applications after changing Herdr configuration because existing processes retain their environment.
+
 Launch a conversation-owned workspace from outside Herdr:
 
 ```bash

--- a/docs/en/configuration/herdr.md
+++ b/docs/en/configuration/herdr.md
@@ -5,7 +5,9 @@ description: Run xcsh conversations with isolated, conversation-owned support te
 
 xcsh can bind one conversation to one Herdr workspace and expose named support terminals as tabs. The recommended full rich-media stack is Ghostty with Kitty graphics, Herdr with `experimental.kitty_graphics=true`, and FFmpeg 6 or newer. Other terminals remain usable and receive static media fallbacks.
 
-When a released Herdr version exposes `HERDR_KITTY_GRAPHICS=1` alongside `HERDR_ENV=1`, xcsh uses the Kitty image protocol for TTY output even though Herdr deliberately reports `TERM=xterm-256color`. Both markers must be exactly `1`; their absence or any other value keeps images disabled for that generic terminal type. `PI_FORCE_IMAGE_PROTOCOL` remains authoritative. This contract requires the xcsh release containing this change and the corresponding future Herdr release; until then, the safe behavior is the text fallback. Restart applications after changing Herdr configuration because existing processes retain their environment.
+When a released Herdr version exposes `HERDR_KITTY_GRAPHICS=1` alongside `HERDR_ENV=1`, xcsh uses the Kitty image protocol for TTY output even though Herdr deliberately reports `TERM=xterm-256color`. Both markers must be exactly `1`; their absence or any other value keeps images disabled for that generic terminal type.
+
+`PI_FORCE_IMAGE_PROTOCOL` remains authoritative. This contract requires the xcsh release containing this change and the corresponding future Herdr release; until then, the safe behavior is the text fallback. Restart applications after changing Herdr configuration because existing processes retain their environment.
 
 Launch a conversation-owned workspace from outside Herdr:
 
@@ -17,6 +19,8 @@ The launcher creates the workspace, writes a mode-`0600` `HerdrBindingV1` under 
 
 Inside the conversation, humans use `/terminal` and the model uses `herdr_terminal`. Both surfaces provide `list`, `create`, `run`, `send`, `read`, `wait`, `status`, `focus`, and `close` actions. Creation is always non-focusing. Focus is an explicit action. A busy terminal rejects the first close and requires a second close with `force: true` (or `/terminal close NAME --force`).
 
-Ownership is enforced by a random `xcsh_owner` metadata token on the workspace and each managed pane. xcsh lists, reads, sends to, focuses, and closes only panes carrying the current binding token. Tabs from other conversations or users are not exposed. Session creation, resume, switching, branching, and tree navigation keep the workspace and tabs while refreshing the stored xcsh session reference.
+Ownership is enforced by a random `xcsh_owner` metadata token on the workspace and each managed pane. xcsh lists, reads, sends to, focuses, and closes only panes carrying the current binding token. Tabs from other conversations or users are not exposed.
+
+Session creation, resume, switching, branching, and tree navigation keep the workspace and tabs while refreshing the stored xcsh session reference.
 
 The socket client uses Herdr protocol 18 over newline-delimited JSON on `HERDR_SOCKET_PATH`. Each request reconnects independently, validates the `ping` protocol version, caps responses at 4 MiB, and uses bounded timeouts so a Herdr restart cannot wedge the chat process.

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -59,8 +59,8 @@ export function isNotificationSuppressed(): boolean {
 	return value === "off" || value === "0" || value === "false";
 }
 
-function getForcedImageProtocol(): ImageProtocol | null | undefined {
-	const raw = $env.PI_FORCE_IMAGE_PROTOCOL?.trim().toLowerCase();
+function getForcedImageProtocol(env: NodeJS.ProcessEnv): ImageProtocol | null | undefined {
+	const raw = env.PI_FORCE_IMAGE_PROTOCOL?.trim().toLowerCase();
 	if (!raw) return undefined;
 	if (raw === "kitty") return ImageProtocol.Kitty;
 	if (raw === "iterm2" || raw === "iterm") return ImageProtocol.Iterm2;
@@ -97,12 +97,21 @@ export function isWindowsTerminalPreviewSixelSupported(
 	if (!version) return false;
 	return version.major > 1 || (version.major === 1 && version.minor >= 22);
 }
-function getFallbackImageProtocol(terminalId: TerminalId): ImageProtocol | null {
-	if (!process.stdout.isTTY) return null;
+function hasHerdrKittyGraphics(env: NodeJS.ProcessEnv): boolean {
+	return env.HERDR_ENV === "1" && env.HERDR_KITTY_GRAPHICS === "1";
+}
+
+function getFallbackImageProtocol(
+	terminalId: TerminalId,
+	env: NodeJS.ProcessEnv,
+	stdoutIsTTY: boolean,
+): ImageProtocol | null {
+	if (!stdoutIsTTY) return null;
+	if (hasHerdrKittyGraphics(env)) return ImageProtocol.Kitty;
 	if (terminalId === "alacritty") return null;
 	// VS Code 1.80+ supports iTerm2 inline image protocol
 	if (terminalId === "vscode") return ImageProtocol.Iterm2;
-	const term = Bun.env.TERM?.toLowerCase() ?? "";
+	const term = env.TERM?.toLowerCase() ?? "";
 	if (term.includes("screen") || term.includes("tmux") || term.includes("ghostty")) {
 		return ImageProtocol.Kitty;
 	}
@@ -121,11 +130,11 @@ const KNOWN_TERMINALS = Object.freeze({
 	alacritty: new TerminalInfo("alacritty", null, true, true, NotifyProtocol.Bell),
 });
 
-export const TERMINAL_ID: TerminalId = (() => {
-	function caseEq(a: string, b: string): boolean {
-		return a.toLowerCase() === b.toLowerCase(); // For compiler to pattern match
-	}
+function caseEq(a: string, b: string): boolean {
+	return a.toLowerCase() === b.toLowerCase(); // For compiler to pattern match
+}
 
+export function resolveTerminalId(env: NodeJS.ProcessEnv): TerminalId {
 	const {
 		KITTY_WINDOW_ID,
 		GHOSTTY_RESOURCES_DIR,
@@ -136,7 +145,7 @@ export const TERMINAL_ID: TerminalId = (() => {
 		TERM_PROGRAM,
 		TERM,
 		COLORTERM,
-	} = Bun.env;
+	} = env;
 
 	if (KITTY_WINDOW_ID) return "kitty";
 	if (GHOSTTY_RESOURCES_DIR) return "ghostty";
@@ -160,11 +169,12 @@ export const TERMINAL_ID: TerminalId = (() => {
 		if (caseEq(COLORTERM, "truecolor") || caseEq(COLORTERM, "24bit")) return "trueColor";
 	}
 	return "base";
-})();
+}
 
-export const TERMINAL = (() => {
-	const terminal = getTerminalInfo(TERMINAL_ID);
-	const forcedImageProtocol = getForcedImageProtocol();
+/** Resolve terminal capabilities from an explicit environment and stdout TTY state. */
+export function resolveTerminalInfo(env: NodeJS.ProcessEnv, stdoutIsTTY: boolean): TerminalInfo {
+	const terminal = getTerminalInfo(resolveTerminalId(env));
+	const forcedImageProtocol = getForcedImageProtocol(env);
 	if (forcedImageProtocol !== undefined) {
 		return new TerminalInfo(
 			terminal.id,
@@ -175,7 +185,7 @@ export const TERMINAL = (() => {
 		);
 	}
 	if (!terminal.imageProtocol) {
-		const fallbackImageProtocol = getFallbackImageProtocol(terminal.id);
+		const fallbackImageProtocol = getFallbackImageProtocol(terminal.id, env, stdoutIsTTY);
 		if (fallbackImageProtocol) {
 			return new TerminalInfo(
 				terminal.id,
@@ -187,7 +197,11 @@ export const TERMINAL = (() => {
 		}
 	}
 	return terminal;
-})();
+}
+
+export const TERMINAL_ID: TerminalId = resolveTerminalId(Bun.env);
+
+export const TERMINAL = resolveTerminalInfo(Bun.env, process.stdout.isTTY ?? false);
 
 type MutableTerminalInfo = {
 	imageProtocol: ImageProtocol | null;

--- a/packages/tui/test/image-render.test.ts
+++ b/packages/tui/test/image-render.test.ts
@@ -6,6 +6,7 @@ import {
 	ImageProtocol,
 	isWindowsTerminalPreviewSixelSupported,
 	renderImage,
+	resolveTerminalInfo,
 	setCellDimensions,
 	TERMINAL,
 } from "@f5-sales-demo/pi-tui/terminal-capabilities";
@@ -110,6 +111,53 @@ describe("terminal image rendering", () => {
 		expect(lines[1]).toContain("\x1b[1A");
 		expect(lines[1]).toContain("c=2");
 		expect(lines[1]).toContain("r=2");
+	});
+});
+
+describe("Herdr Kitty graphics capability", () => {
+	it("selects Kitty and emits graphics for an explicitly capable Herdr pane", () => {
+		const resolved = resolveTerminalInfo({ TERM: "xterm-256color", HERDR_ENV: "1", HERDR_KITTY_GRAPHICS: "1" }, true);
+		expect(resolved.imageProtocol).toBe(ImageProtocol.Kitty);
+
+		const originalProtocol = terminal.imageProtocol;
+		terminal.imageProtocol = resolved.imageProtocol;
+		try {
+			const result = renderImage(BASE64_DUMMY, SQUARE_DIMENSIONS);
+			expect(result?.sequence.startsWith(ImageProtocol.Kitty)).toBe(true);
+		} finally {
+			terminal.imageProtocol = originalProtocol;
+		}
+	});
+
+	it("requires exact enabled Herdr markers and TTY output", () => {
+		for (const env of [
+			{ TERM: "xterm-256color" },
+			{ TERM: "xterm-256color", HERDR_ENV: "1" },
+			{ TERM: "xterm-256color", HERDR_KITTY_GRAPHICS: "1" },
+			{ TERM: "xterm-256color", HERDR_ENV: "yes", HERDR_KITTY_GRAPHICS: "1" },
+			{ TERM: "xterm-256color", HERDR_ENV: "1", HERDR_KITTY_GRAPHICS: "0" },
+			{ TERM: "xterm-256color", HERDR_ENV: "1", HERDR_KITTY_GRAPHICS: "true" },
+		]) {
+			expect(resolveTerminalInfo(env, true).imageProtocol).toBeNull();
+		}
+		expect(
+			resolveTerminalInfo({ TERM: "xterm-256color", HERDR_ENV: "1", HERDR_KITTY_GRAPHICS: "1" }, false)
+				.imageProtocol,
+		).toBeNull();
+	});
+
+	it("preserves explicit image-protocol override precedence", () => {
+		const env = { TERM: "xterm-256color", HERDR_ENV: "1", HERDR_KITTY_GRAPHICS: "1" };
+		expect(resolveTerminalInfo({ ...env, PI_FORCE_IMAGE_PROTOCOL: "off" }, true).imageProtocol).toBeNull();
+		expect(resolveTerminalInfo({ ...env, PI_FORCE_IMAGE_PROTOCOL: "kitty" }, true).imageProtocol).toBe(
+			ImageProtocol.Kitty,
+		);
+		expect(resolveTerminalInfo({ ...env, PI_FORCE_IMAGE_PROTOCOL: "iterm2" }, true).imageProtocol).toBe(
+			ImageProtocol.Iterm2,
+		);
+		expect(resolveTerminalInfo({ ...env, PI_FORCE_IMAGE_PROTOCOL: "sixel" }, true).imageProtocol).toBe(
+			ImageProtocol.Sixel,
+		);
 	});
 });
 


### PR DESCRIPTION
## What

Adds a pure terminal-capability resolver that selects Kitty graphics only for TTY output in an explicitly capable Herdr pane.

## Why

Herdr intentionally reports TERM=xterm-256color, so xcsh otherwise selects its text image fallback even when the outer terminal can render Kitty graphics.

## Testing

- [x] Focused `packages/tui/test/image-render.test.ts`
- [x] `bun run check:tools`
- [ ] `bun run test` is still running; its result will be recorded before merge.
- [ ] `bun run check:ts` currently fails in an unrelated chat-ui test because its check script does not preload JSDOM.

Closes #3254

Refs https://github.com/herdrdev/herdr/issues/2907