### PR TITLE
Fix provider publication digest qualifier contract

### DIFF
--- a/.github/workflows/api-spec-update.yml
+++ b/.github/workflows/api-spec-update.yml
@@ -191,7 +191,7 @@ jobs:
                   ("terraform-provider-xcsh_" + .value.publication.version + "_windows_386.zip"),
                   ("terraform-provider-xcsh_" + .value.publication.version + "_windows_amd64.zip")
                 ] and
-                ([.value.publication.assets[] | test("^[0-9a-f]{64}$")] | all)
+                ([.value.publication.assets[] | test("^sha256:[0-9a-f]{64}$")] | all)
               ' >/dev/null || { echo "::error::Provider publication ledger contains malformed evidence"; exit 1; }
             done < <(printf '%s' "$PROVIDER_EVIDENCE" | jq -c '.receipts | to_entries[]')
 
@@ -243,7 +243,7 @@ jobs:
                     [.assets[] | select(.name == $name)] |
                     if length == 1 then .[0].digest else empty end')
                   RECEIPT_DIGEST=$(printf '%s' "$EVIDENCE" | jq -r --arg name "$ASSET" '.assets[$name]')
-                  [ "$API_DIGEST" = "sha256:$RECEIPT_DIGEST" ] || {
+                  [ "$API_DIGEST" = "$RECEIPT_DIGEST" ] || {
                     echo "::error::Provider release bytes differ from publication evidence for $ASSET"
                     exit 1
                   }

--- a/packages/coding-agent/test/scripts/api-spec-update-workflow.test.ts
+++ b/packages/coding-agent/test/scripts/api-spec-update-workflow.test.ts
@@ -182,6 +182,24 @@ describe("provider publication evidence gate", () => {
 		}
 	}, 60_000);
 
+	it("rejects unqualified provider publication digests", async () => {
+		const fixture = await providerEvidenceFixture();
+		try {
+			const detailed = await Bun.file(fixture.env.FIXTURE_DETAILED).json();
+			const deliveryId = Object.keys(detailed.receipts)[0];
+			const assets = detailed.receipts[deliveryId].publication.assets as Record<string, string>;
+			for (const [name, digest] of Object.entries(assets)) {
+				assets[name] = digest.replace(/^sha256:/, "");
+			}
+			await Bun.write(fixture.env.FIXTURE_DETAILED, `${JSON.stringify(detailed)}\n`);
+			const result = await runProviderEvidenceStep(fixture);
+			expect(result.exitCode).not.toBe(0);
+			expect(result.output).toContain("Provider publication ledger contains malformed evidence");
+		} finally {
+			await fs.rm(fixture.root, { force: true, recursive: true });
+		}
+	}, 60_000);
+
 	it("rejects noncanonical and mismatched provider ledgers", async () => {
 		const noncanonical = await providerEvidenceFixture();
 		try {
@@ -279,7 +297,10 @@ async function providerEvidenceFixture(falseDigest = false): Promise<ProviderEvi
 	})}\n`;
 	const pinSha = new Bun.CryptoHasher("sha256").update(pin).digest("hex");
 	const assets = Object.fromEntries(
-		providerAssetNames(providerVersion).map((name, index) => [name, (index + 1).toString(16).padStart(64, "0")]),
+		providerAssetNames(providerVersion).map((name, index) => [
+			name,
+			`sha256:${(index + 1).toString(16).padStart(64, "0")}`,
+		]),
 	);
 	const evidence = {
 		assets,
@@ -305,7 +326,7 @@ async function providerEvidenceFixture(falseDigest = false): Promise<ProviderEvi
 	};
 	const release = {
 		assets: providerAssetNames(providerVersion).map(name => ({
-			digest: `sha256:${falseDigest && name.startsWith("mcp-data-") ? "0".repeat(64) : assets[name]}`,
+			digest: falseDigest && name.startsWith("mcp-data-") ? `sha256:${"0".repeat(64)}` : assets[name],
 			name,
 		})),
 		body: `notes\n<!-- provider-publication-receipt:${JSON.stringify(evidence)} -->\n`,


### PR DESCRIPTION
## Summary

Accept the canonical `sha256:<hex>` digest format stored in provider publication receipts so the API-spec delivery workflow can resolve and verify the exact published provider release.

## Related Issue

Closes #3284

## Changes

- validate all provider receipt asset digests as qualified SHA-256 values
- compare GitHub release digests directly with the receipt values
- update fixtures and add explicit rejection coverage for legacy unqualified values

## Verification evidence

- `bun test packages/coding-agent/test/scripts/api-spec-update-workflow.test.ts` — 11 pass, 0 fail, 97 expectations
- `bun run check` — passed
- `bun run lint` — passed
- `bun run test` — passed (`FULL_RC=0`; main xcsh package 7,220 tests, 0 failures)
- `actionlint .github/workflows/api-spec-update.yml` — passed
- `bunx @biomejs/biome check .github/workflows/api-spec-update.yml packages/coding-agent/test/scripts/api-spec-update-workflow.test.ts` — passed
- `bash scripts/check-pii.sh --scope head --mode enforce` — clean
- `pre-commit run --all-files` — applicable code/security hooks passed; repository baseline remains in untouched Markdown terminology and unrelated `macos-15-intel` actionlint configuration
- AGY review — N/A under the task-specific lint/syntax-fix waiver

## Delivery evidence

- Candidate commit: `84de3e96d382f239263ff1dd8e0b5f67ff9368ce`
- Rebased against current `origin/main` at `e47bbd7aecca1ea40ff1a44a0fda1b05fdc58bfc` before push
- Canonical delivery replay will follow merge and must complete green before recovery item 2 is closed

## Checklist

- [x] Linked to a detailed issue with `Closes #N`
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above

- [ ] Pending, failed, behind, or conflicted states repaired through `MERGED`
- [ ] Worktree and confirmed-merged branch cleaned; fleet convergence confirmed when applicable
- [x] Follows project conventions and style guides
