### PR TITLE
Fix provider spec-pin digest qualifier contract

### DIFF
--- a/.github/workflows/api-spec-update.yml
+++ b/.github/workflows/api-spec-update.yml
@@ -265,7 +265,7 @@ jobs:
                   (.assets | keys | sort) == [
                     "api-catalog.json", ("f5xc-api-specs-" + $tag + ".zip"),
                     "index.json", "minimal-export-defaults.json", "openapi.json"
-                  ] and ([.assets[] | test("^[0-9a-f]{64}$")] | all)
+                  ] and ([.assets[] | test("^sha256:[0-9a-f]{64}$")] | all)
                 ' "$RUNNER_TEMP/provider-spec-release.json" >/dev/null || {
                   echo "::error::Provider release carries a malformed or mismatched spec pin"
                   exit 1

--- a/packages/coding-agent/test/scripts/api-spec-update-workflow.test.ts
+++ b/packages/coding-agent/test/scripts/api-spec-update-workflow.test.ts
@@ -200,6 +200,17 @@ describe("provider publication evidence gate", () => {
 		}
 	}, 60_000);
 
+	it("rejects unqualified provider spec pin digests", async () => {
+		const fixture = await providerEvidenceFixture(false, true);
+		try {
+			const result = await runProviderEvidenceStep(fixture);
+			expect(result.exitCode).not.toBe(0);
+			expect(result.output).toContain("Provider release carries a malformed or mismatched spec pin");
+		} finally {
+			await fs.rm(fixture.root, { force: true, recursive: true });
+		}
+	}, 60_000);
+
 	it("rejects noncanonical and mismatched provider ledgers", async () => {
 		const noncanonical = await providerEvidenceFixture();
 		try {
@@ -263,7 +274,7 @@ interface ProviderEvidenceFixture {
 	env: Record<string, string>;
 }
 
-async function providerEvidenceFixture(falseDigest = false): Promise<ProviderEvidenceFixture> {
+async function providerEvidenceFixture(falseDigest = false, unqualifiedPin = false): Promise<ProviderEvidenceFixture> {
 	const root = await fs.mkdtemp(path.join(os.tmpdir(), "xcsh-provider-evidence-"));
 	const bin = path.join(root, "bin");
 	await fs.mkdir(bin);
@@ -283,13 +294,14 @@ async function providerEvidenceFixture(falseDigest = false): Promise<ProviderEvi
 		},
 		"f5-sales-demo/terraform-provider-xcsh",
 	);
+	const pinDigest = (digit: string) => `${unqualifiedPin ? "" : "sha256:"}${digit.repeat(64)}`;
 	const pin = `${JSON.stringify({
 		assets: {
-			"api-catalog.json": "1".repeat(64),
-			[`f5xc-api-specs-${specTag}.zip`]: "2".repeat(64),
-			"index.json": "3".repeat(64),
-			"minimal-export-defaults.json": "4".repeat(64),
-			"openapi.json": "5".repeat(64),
+			"api-catalog.json": pinDigest("1"),
+			[`f5xc-api-specs-${specTag}.zip`]: pinDigest("2"),
+			"index.json": pinDigest("3"),
+			"minimal-export-defaults.json": pinDigest("4"),
+			"openapi.json": pinDigest("5"),
 		},
 		release_tag: specTag,
 		target_commit: specCommit,


### PR DESCRIPTION
## Summary

Accept canonical `sha256:<hex>` values in the provider's exact API-spec release pin so the recovery delivery can verify the bytes consumed by the published provider.

## Related Issue

Closes #3286

## Changes

- require qualified SHA-256 values for all five provider spec-pin assets
- update the successful fixture to the published canonical format
- add explicit rejection coverage for unqualified spec-pin values

## Verification evidence

- `bun test packages/coding-agent/test/scripts/api-spec-update-workflow.test.ts` — 12 pass, 0 fail, 99 expectations
- `bun run check` — passed
- `bun run lint` — passed
- `bun run test` — passed (`FULL2_RC=0`; xcsh package 7,221 tests, 0 failures)
- `actionlint .github/workflows/api-spec-update.yml` — passed
- `git diff --check origin/main...HEAD` — passed
- AGY review — N/A under the task-specific lint/syntax-fix waiver

## Delivery evidence

- Candidate commit: `340b65306eb27e574c7296514ef9e87273c2547c`
- Synchronized with `origin/main` at `5c3c77e335e7c4daa77ce4f34bdf9df86da5d378`
- Failed recovery run proving the prior bare-hash assumption: https://github.com/f5-sales-demo/xcsh/actions/runs/32268890240
- Canonical delivery replay will resume after merge

## Checklist

- [x] Linked to a detailed issue with `Closes #N`
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above

- [ ] Pending, failed, behind, or conflicted states repaired through `MERGED`
- [ ] Worktree and confirmed-merged branch cleaned; fleet convergence confirmed when applicable
- [x] Follows project conventions and style guides
