### PR TITLE
fix(terraform): support typed resource index

### DIFF
--- a/packages/coding-agent/src/internal-urls/terraform-resolve.ts
+++ b/packages/coding-agent/src/internal-urls/terraform-resolve.ts
@@ -6,6 +6,7 @@ export interface TerraformResolver {
 }
 
 export function createTerraformResolver(index: TerraformIndex): TerraformResolver {
+	const resources = normalizeResources(index.resources);
 	const categoryBySlug = new Map<string, TerraformCategory>();
 	for (const cat of index.categories) {
 		categoryBySlug.set(cat.slug, cat);
@@ -32,30 +33,35 @@ export function createTerraformResolver(index: TerraformIndex): TerraformResolve
 				const slug = parts[0]!;
 
 				const cat = categoryBySlug.get(slug);
-				if (cat) return makeResource(url, renderL1(cat, index.resources));
+				if (cat) return makeResource(url, renderL1(cat, resources));
 
-				const res = index.resources[slug];
+				const res = resources[slug];
 				if (res) {
 					const catSlug = resourceToCategory.get(slug) ?? "";
 					return makeResource(url, renderL2(slug, res, catSlug));
 				}
 
-				return makeResource(url, renderUnknown(slug, index));
+				return makeResource(url, renderUnknown(slug, resources));
 			}
 
 			if (parts.length === 2) {
 				const resourceName = parts[1]!;
-				const res = index.resources[resourceName];
+				const res = resources[resourceName];
 				if (res) {
 					const realCategory = resourceToCategory.get(resourceName) ?? parts[0]!;
 					return makeResource(url, renderL2(resourceName, res, realCategory));
 				}
-				return makeResource(url, renderUnknown(resourceName, index));
+				return makeResource(url, renderUnknown(resourceName, resources));
 			}
 
-			return makeResource(url, renderUnknown(pathname, index));
+			return makeResource(url, renderUnknown(pathname, resources));
 		},
 	};
+}
+
+function normalizeResources(resources: TerraformIndex["resources"]): Readonly<Record<string, TerraformResource>> {
+	if (!Array.isArray(resources)) return resources as Readonly<Record<string, TerraformResource>>;
+	return Object.fromEntries(resources.map(resource => [resource.name, resource]));
 }
 
 function makeResource(url: InternalUrl, content: string): InternalResource {
@@ -158,7 +164,12 @@ function renderL2(name: string, res: TerraformResource, _categorySlug: string): 
 	}
 
 	if (res.minimal_config) {
-		lines.push("", "## Config", "", "```terraform", res.minimal_config, "```");
+		lines.push("", "## Config", "");
+		if (typeof res.minimal_config === "string") {
+			lines.push("```terraform", res.minimal_config, "```");
+		} else {
+			lines.push(`Configuration source (${res.minimal_config.format}): \`${res.minimal_config.source}\``);
+		}
 	}
 
 	lines.push("", `Import: \`${res.import_syntax}\``);
@@ -169,8 +180,8 @@ function renderL2(name: string, res: TerraformResource, _categorySlug: string): 
 	return lines.join("\n");
 }
 
-function renderUnknown(query: string, index: TerraformIndex): string {
-	const allNames = Object.keys(index.resources);
+function renderUnknown(query: string, resources: Readonly<Record<string, TerraformResource>>): string {
+	const allNames = Object.keys(resources);
 	const matches = allNames.filter(n => n.includes(query)).slice(0, 5);
 	const suggestion =
 		matches.length > 0 ? `\nDid you mean: ${matches.join(", ")}` : "\nUse `xcsh://terraform/` to list categories.";

--- a/packages/coding-agent/src/internal-urls/terraform-types.ts
+++ b/packages/coding-agent/src/internal-urls/terraform-types.ts
@@ -17,15 +17,24 @@ export interface TerraformDependencies {
 	readonly used_by?: readonly string[];
 }
 
+export interface TerraformMinimalConfigReference {
+	readonly format: "terraform";
+	readonly source: string;
+}
+
 export interface TerraformResource {
 	readonly category: string;
 	readonly description: string;
 	readonly required: readonly string[];
 	readonly oneof_groups?: readonly TerraformOneOfGroup[];
 	readonly server_defaults?: readonly string[];
-	readonly minimal_config?: string;
+	readonly minimal_config?: string | TerraformMinimalConfigReference;
 	readonly dependencies: TerraformDependencies;
 	readonly import_syntax: string;
+}
+
+export interface TerraformNamedResource extends TerraformResource {
+	readonly name: string;
 }
 
 export interface TerraformCategory {
@@ -41,5 +50,5 @@ export interface TerraformIndex {
 	readonly version: string;
 	readonly provider: TerraformProvider;
 	readonly categories: readonly TerraformCategory[];
-	readonly resources: Readonly<Record<string, TerraformResource>>;
+	readonly resources: Readonly<Record<string, TerraformResource>> | readonly TerraformNamedResource[];
 }

--- a/packages/coding-agent/test/internal-urls/terraform-resolve.test.ts
+++ b/packages/coding-agent/test/internal-urls/terraform-resolve.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test";
+import { parseInternalUrl } from "../../src/internal-urls/parse";
+import { createTerraformResolver } from "../../src/internal-urls/terraform-resolve";
+import type { TerraformIndex } from "../../src/internal-urls/terraform-types";
+
+const provider = {
+	auth_methods: [],
+	config_block: 'provider "xcsh" {}',
+	registry: "registry.terraform.io/f5/xcsh",
+	required_block: 'terraform { required_providers { xcsh = { source = "f5/xcsh" } } }',
+	source: "f5-sales-demo/terraform-provider-xcsh",
+	syntax_rules: [],
+};
+
+const category = {
+	description: "Security resources",
+	name: "Security",
+	resource_count: 1,
+	resources: ["app_firewall"],
+	slug: "security",
+};
+
+describe("createTerraformResolver", () => {
+	it("resolves provider typed resource arrays and renders config references as provenance", async () => {
+		const index = {
+			categories: [category],
+			provider,
+			resources: [
+				{
+					category: "security",
+					dependencies: { requires: ["namespace"] },
+					description: "Application Firewall",
+					import_syntax: "terraform import xcsh_app_firewall.example namespace/name",
+					minimal_config: {
+						format: "terraform",
+						source: "_llms-txt/resources/app_firewall.txt#minimal-valid-config",
+					},
+					name: "app_firewall",
+					required: ["name", "namespace"],
+				},
+			],
+			version: "0.1.0",
+		} as TerraformIndex;
+
+		const resolver = createTerraformResolver(index);
+		const resource = await resolver.resolve(parseInternalUrl("xcsh://terraform/security/app_firewall") as never);
+		const categoryListing = await resolver.resolve(parseInternalUrl("xcsh://terraform/security") as never);
+
+		expect(resource.content).toContain("Application Firewall");
+		expect(resource.content).toContain("Configuration source");
+		expect(resource.content).toContain("_llms-txt/resources/app_firewall.txt#minimal-valid-config");
+		expect(resource.content).not.toContain("[object Object]");
+		expect(categoryListing.content).toContain("Application Firewall");
+	});
+
+	it("preserves legacy resource maps and inline minimum configs", async () => {
+		const index: TerraformIndex = {
+			categories: [category],
+			provider,
+			resources: {
+				app_firewall: {
+					category: "security",
+					dependencies: { requires: [] },
+					description: "Application Firewall",
+					import_syntax: "terraform import xcsh_app_firewall.example namespace/name",
+					minimal_config: 'resource "xcsh_app_firewall" "example" {}',
+					required: ["name", "namespace"],
+				},
+			},
+			version: "0.1.0",
+		};
+
+		const resource = await createTerraformResolver(index).resolve(
+			parseInternalUrl("xcsh://terraform/app_firewall") as never,
+		);
+		expect(resource.content).toContain('resource "xcsh_app_firewall" "example" {}');
+		expect(resource.content).toContain("```terraform");
+	});
+});


### PR DESCRIPTION
Closes #3292

Accept the provider’s typed Terraform resource array and structured minimal-config references while preserving the legacy map/string format.

Validation:
- `bun run check`
- `bun run lint`
- `bun run test` (7,224 xcsh tests; 0 failures)
- focused resolver tests (2 passed)
- file-scoped pre-commit hooks

AGY: N/A — task-specific waiver for lint/syntax recovery fixes.