### PR TITLE
fix Gitleaks handling of generated spec digests

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -2,3 +2,10 @@ title = "Fleet default Gitleaks rules"
 
 [extend]
 useDefault = true
+
+[[allowlists]]
+description = "Generated API-spec asset SHA-256 digests"
+condition = "AND"
+regexTarget = "secret"
+paths = ['''(?:^|/)tools/spec-release\.json$''']
+regexes = ['''^[0-9a-f]{64}$''']


### PR DESCRIPTION
Closes #3298

Allow exact lowercase SHA-256 values only when they appear in the generated `tools/spec-release.json` path. The path and secret regex must both match, so the same digest-shaped value elsewhere remains subject to Gitleaks.

Validation:
- canonical v2.1.221 generated worktree: zero Gitleaks findings
- boundary probe: the generated path is allowed while the same bytes outside that path produce three findings
- repository pre-commit hooks for `.gitleaks.toml`
- AGY: N/A under the explicit lint/syntax-fix waiver
