### PR TITLE
ci: establish container-build runner smoke baseline

### DIFF
--- a/.github/workflows/self-hosted-runner-cache-smoke.yml
+++ b/.github/workflows/self-hosted-runner-cache-smoke.yml
@@ -4,62 +4,32 @@ name: Self-hosted Runner Cache Smoke
 on:
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   group: self-hosted-runner-cache-smoke-${{ github.repository }}
   cancel-in-progress: false
 
 jobs:
-  cache-smoke:
-    name: Validate immutable image and private tool cache
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
-    timeout-minutes: 10
+  container-build-smoke:
+    name: Validate container-build Docker route
+    runs-on: [self-hosted, Linux, X64, xcsh, container-build]
+    timeout-minutes: 5
     steps:
-      - name: Assert immutable image and runtime cache boundary
+      - name: Build and inspect a scratch image through the Docker socket
         shell: bash
         run: |
           set -euo pipefail
-          : "${RUNNER_RUNTIME_DIR:?RUNNER_RUNTIME_DIR must be set}"
-          : "${RUNNER_TOOL_CACHE:?RUNNER_TOOL_CACHE must be set}"
+          test -S /run/docker.sock
+          : "${DOCKER_HOST:=unix:///run/docker.sock}"
+          export DOCKER_HOST
+          docker version
+          docker buildx version
+          docker compose version
 
-          runtime_dir="$(realpath -m -- "$RUNNER_RUNTIME_DIR")"
-          tool_cache="$(realpath -m -- "$RUNNER_TOOL_CACHE")"
-          test "$tool_cache" = "$runtime_dir/_tool"
-          test -d "$tool_cache"
-          test -f "$tool_cache/go/1.25.12/x64.complete"
-          test -f /opt/hostedtoolcache/go/1.25.12/x64.complete
+          image="xcsh-container-build-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          cleanup() { docker image rm --force "$image" >/dev/null 2>&1 || true; }
+          trap cleanup EXIT
 
-          if touch /.self-hosted-runner-cache-smoke; then
-            rm -f /.self-hosted-runner-cache-smoke
-            echo "the runner root filesystem must be read-only" >&2
-            exit 1
-          fi
-          if touch /opt/hostedtoolcache/.self-hosted-runner-cache-smoke; then
-            rm -f /opt/hostedtoolcache/.self-hosted-runner-cache-smoke
-            echo "the image tool cache must be read-only" >&2
-            exit 1
-          fi
-
-          printf 'runtime tool cache: %s\n' "$tool_cache"
-          stat -c '%A %U:%G %n' / /opt/hostedtoolcache "$tool_cache"
-
-      - name: Resolve catalogued Go from the private tool cache
-        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
-        with:
-          go-version: 1.25.12
-          cache: false
-          check-latest: false
-
-      - name: Verify catalogued Go version
-        shell: bash
-        run: |
-          set -euo pipefail
-          test "$(go env GOVERSION)" = go1.25.12
-          test -f "$RUNNER_TOOL_CACHE/go/1.25.12/x64.complete"
-
-      - name: Resolve an uncatalogued Go version into the runtime cache
-        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
-        with:
-          go-version: 1.25.11
+          printf 'FROM scratch\n' | docker build --tag "$image" -
+          docker image inspect "$image"


### PR DESCRIPTION
## Recovery baseline

Closes #3332.

This emergency recovery PR changes only the manual smoke workflow. It uses no checkout, actions, secrets, comments, artifacts, publishing, or API/status writes; has `permissions: {}`; routes only to the approved `xcsh` `container-build` profile; checks Docker client/server, Buildx, Compose, and socket connectivity; then builds, inspects, and removes one uniquely tagged `FROM scratch` image.

Validation: YAML parse and `git diff --check` passed. Broad CI, linting, and AGY are intentionally out of scope for the approved minimal baseline.

Merge authorization: documented emergency branch-protection bypass; this is the sole recovery-PR merge exception while existing PRs remain frozen.
