### PR TITLE
ci: add advisory same-repository PR runner smoke

### DIFF
--- a/.github/workflows/self-hosted-runner-cache-smoke.yml
+++ b/.github/workflows/self-hosted-runner-cache-smoke.yml
@@ -3,6 +3,8 @@ name: Self-hosted Runner Cache Smoke
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches: [main]
 
 permissions: {}
 
@@ -12,6 +14,7 @@ concurrency:
 
 jobs:
   container-build-smoke:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     name: Validate container-build Docker route
     runs-on: [self-hosted, Linux, X64, xcsh, container-build]
     timeout-minutes: 5


### PR DESCRIPTION
## Summary

- adds an advisory `pull_request` trigger for `main` to the existing self-hosted runner smoke
- gates the sole job to same-repository pull requests
- preserves manual dispatch, empty permissions, exact `container-build` labels, and scratch-image cleanup

## Validation

- `actionlint .github/workflows/self-hosted-runner-cache-smoke.yml`
- workflow invariant checks for permissions, labels, same-repository guard, and no checkout/actions/secrets/API commands
- `bash scripts/agy-review.sh code --base origin/main` (clean PII preflight; both structured reports passed)

Closes #3334
