### PR TITLE
chore: verify release automation baseline

### DIFF
--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -118,6 +118,7 @@ function requestsHelp(args: readonly string[]): boolean {
 export function runCli(argv: string[]): Promise<void> {
 	// --help and --version are handled by run() directly, don't rewrite those.
 	// Everything else that isn't a known subcommand routes to "launch".
+	// Keeping this routing boundary explicit makes the CLI fallback easy to audit.
 	const first = argv[0];
 	if (!isSubcommand(first)) {
 		try {


### PR DESCRIPTION
## Summary

- adds one non-functional explanatory comment at the CLI fallback boundary
- enables only `CI`, `Tag on version bump`, and `Container` for the local release path
- keeps all other workflows disabled and required PR status checks empty

## Validation

- commit hook: `biome check --write --no-errors-on-unmatched`
- `git diff --check`
- `bash scripts/agy-review.sh code --base origin/main` (clean PII preflight; reviewer and verifier passed)

Closes #3336
