### PR TITLE
ci: refresh pinned GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,7 +365,7 @@ jobs:
           lookup-only: true
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
-      - uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
+      - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518 # v2.86.5
         with:
           tool: nextest
       - name: Verify immutable runner dependencies

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -39,7 +39,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
         with:
           driver: docker-container
           name: xcsh-container-build-cache
@@ -103,7 +103,7 @@ jobs:
           platforms: arm64
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
         with:
           driver: docker-container
           name: xcsh-container-build-cache

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Upload SARIF to Code Scanning
         if: always() && hashFiles('semgrep.sarif') != ''
-        uses: github/codeql-action/upload-sarif@a2983b8bed1923f44751c5c43237f479442827b3 # v3.37.4
+        uses: github/codeql-action/upload-sarif@37f2634a92ba38a0926ef79a0748ac8ae7d95ab2 # v4.37.8
         with:
           sarif_file: semgrep.sarif
           category: semgrep

--- a/.github/workflows/workflow-security-audit.yml
+++ b/.github/workflows/workflow-security-audit.yml
@@ -50,7 +50,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up pinned Python and uv
-        uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: '0.8.24'
           python-version: '3.13.7'


### PR DESCRIPTION
## Summary

Refreshes four direct immutable GitHub Action pins to their verified current releases:

- docker/setup-buildx-action v4.3.0
- astral-sh/setup-uv v10.0.1
- github/codeql-action/upload-sarif v4.37.8
- taiki-e/install-action v2.86.5

No triggers, permissions, runner labels, required checks, or managed reusable workflow references change.

## Validation

- actionlint passes with only the pre-existing macos-15-intel label warning excluded
- bun run ci:check:full
- AGY reviewer and verifier: approve, no findings

Closes #3340