### PR TITLE
chore: verify required linked-issue check

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,5 @@ branch naming, and CI requirements.
 ## License
 
 See [LICENSE](LICENSE).
+
+<!-- Verify the required linked-issue check on this same-repository PR. -->


### PR DESCRIPTION
## Verification

This same-repository PR changes only a non-substantive README HTML comment to exercise the enabled linked-issue workflow on the xcsh self-hosted Ubuntu runner.

Closes #3345