### PR TITLE
Normalize linked issue runner label

### DIFF
--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -15,7 +15,7 @@ jobs:
   pr-check:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     name: Check linked issues
-    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     permissions:
       pull-requests: read # query this event's exact PR and its closing issue references
     steps:


### PR DESCRIPTION
Normalize only the linked-issue runner label to use the repository-name expression; all other workflow behavior and the existing required app-scoped check remain unchanged.

Closes #3347
