### PR TITLE
fix(lint): pin shared Biome scope repair

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -16,7 +16,7 @@ jobs:
   lint:
     # No `secrets:` — least privilege. The reusable uses only the automatic
     # GITHUB_TOKEN, so passing repository secrets would over-provision it.
-    uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@ea6e46327deee603c814af75e3abfc0ffb6bfef3
+    uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@5dc50c4e3187157e46c644b04a3e0ed5825fa754
     with:
       classify_xc_minimum_configs: ${{ github.repository == 'f5-sales-demo/terraform-provider-xcsh' }}
     permissions:


### PR DESCRIPTION
Closes #3351

Manually updates only the immutable shared Super-Linter caller pin to docs-control commit `5dc50c4e3187157e46c644b04a3e0ed5825fa754`, which scopes the external Biome gate to changed supported files. No fanout or managed-file synchronization is enabled.
