### PR TITLE
ci(lint): gate Super-Linter on linked issues

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -13,7 +13,38 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  linked-issue:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    name: Check linked issues
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
+    permissions:
+      pull-requests: read # query this event's exact PR and its closing issue references
+    steps:
+      - name: Check this pull request's linked issues
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const number = context.payload.pull_request.number;
+            const result = await github.graphql(
+              `query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    closingIssuesReferences(first: 1) { nodes { number } }
+                  }
+                }
+              }`,
+              { owner, repo, number },
+            );
+            const linked = result.repository.pullRequest.closingIssuesReferences.nodes;
+            if (linked.length === 0) {
+              core.setFailed("Pull request must link a GitHub issue. Add 'Closes #123' to the PR description or link an issue from the sidebar.");
+            } else {
+              core.info(`PR #${number} links issue #${linked[0].number}`);
+            }
+
   lint:
+    needs: linked-issue
     # No `secrets:` — least privilege. The reusable uses only the automatic
     # GITHUB_TOKEN, so passing repository secrets would over-provision it.
     uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@5dc50c4e3187157e46c644b04a3e0ed5825fa754


### PR DESCRIPTION
## Summary

- run the existing `Check linked issues` GraphQL validation as the first Super-Linter caller job
- make the reusable `lint` job depend on that validation, preventing lint dispatch when no issue is linked
- retain the current immutable docs-control pin, permissions, inputs, runner labels, and concurrency

## Validation

- `actionlint .github/workflows/super-linter.yml`
- `bash tests/test-lint-mdx-prose.sh`
- `git diff --check origin/main...HEAD`

## Deferred

- standalone `Require Linked Issue` retirement and branch-protection updates remain intentionally deferred until the caller canary is accepted.

Closes #3353
