### PR TITLE
fix(ci): verify published platforms through BuildKit

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -158,7 +158,32 @@ jobs:
             exit 1
           fi
 
-          test "$(docker run --rm --platform linux/amd64 --entrypoint uname "$IMAGE" -m)" = "x86_64"
-          docker run --rm --platform linux/amd64 "$IMAGE" --version
-          test "$(docker run --rm --platform linux/arm64 --entrypoint uname "$IMAGE" -m)" = "aarch64"
-          docker run --rm --platform linux/arm64 "$IMAGE" --version
+          index_digest="sha256:$(docker buildx imagetools inspect --raw "$IMAGE" | sha256sum | awk '{print $1}')"
+          published_image="${IMAGE%:*}@${index_digest}"
+          expected_version="${GITHUB_REF_NAME#v}"
+
+          verify_platform() {
+            local platform="$1"
+            local expected_machine="$2"
+            # shellcheck disable=SC2016 # Docker expands these build arguments.
+            printf '%s\n' \
+              '# check=skip=InvalidDefaultArgInFrom' \
+              'ARG IMAGE' \
+              'FROM ${IMAGE}' \
+              'ARG EXPECTED_MACHINE' \
+              'ARG EXPECTED_VERSION' \
+              'RUN set -eux; test "$(uname -m)" = "${EXPECTED_MACHINE}"; test "$(xcsh --version)" = "xcsh/${EXPECTED_VERSION}"' | \
+              docker buildx build \
+              --platform "$platform" \
+              --pull \
+              --no-cache \
+              --progress plain \
+              --output type=cacheonly \
+              --build-arg "IMAGE=$published_image" \
+              --build-arg "EXPECTED_MACHINE=$expected_machine" \
+              --build-arg "EXPECTED_VERSION=$expected_version" \
+              -
+          }
+
+          verify_platform linux/amd64 x86_64
+          verify_platform linux/arm64 aarch64

--- a/scripts/tdd-docker.sh
+++ b/scripts/tdd-docker.sh
@@ -108,6 +108,19 @@ grep -Fq 'runs-on: [self-hosted, Linux, X64, xcsh, container-build]' .github/wor
 grep -Fq 'docker/build-push-action@' .github/workflows/container.yml
 grep -Fq 'docker/setup-qemu-action@' .github/workflows/container.yml
 grep -Fq 'platforms: linux/amd64,linux/arm64' .github/workflows/container.yml
+grep -Fq 'docker buildx build' .github/workflows/container.yml
+grep -Fq 'index_digest="sha256:$(docker buildx imagetools inspect --raw' .github/workflows/container.yml
+grep -Fq "printf '%s\\n'" .github/workflows/container.yml
+grep -Fq '# check=skip=InvalidDefaultArgInFrom' .github/workflows/container.yml
+grep -Fq 'EXPECTED_MACHINE' .github/workflows/container.yml
+if grep -Fq "<<'DOCKERFILE'" .github/workflows/container.yml; then
+	echo "ERROR: Published image verification uses a YAML-ambiguous heredoc." >&2
+	exit 1
+fi
+if grep -Eq 'docker run .*--platform linux/(amd64|arm64)' .github/workflows/container.yml; then
+  echo "ERROR: Published multi-platform verification bypasses the isolated BuildKit emulator." >&2
+  exit 1
+fi
 grep -Fq 'ARG TARGETARCH' Dockerfile.alpine
 grep -Fq 'bun_arch=x64-baseline' Dockerfile.alpine
 grep -Fq 'export TARGET_VARIANT=baseline' Dockerfile.alpine

--- a/scripts/tdd-docker.sh
+++ b/scripts/tdd-docker.sh
@@ -114,8 +114,8 @@ grep -Fq "printf '%s\\n'" .github/workflows/container.yml
 grep -Fq '# check=skip=InvalidDefaultArgInFrom' .github/workflows/container.yml
 grep -Fq 'EXPECTED_MACHINE' .github/workflows/container.yml
 if grep -Fq "<<'DOCKERFILE'" .github/workflows/container.yml; then
-	echo "ERROR: Published image verification uses a YAML-ambiguous heredoc." >&2
-	exit 1
+  echo "ERROR: Published image verification uses a YAML-ambiguous heredoc." >&2
+  exit 1
 fi
 if grep -Eq 'docker run .*--platform linux/(amd64|arm64)' .github/workflows/container.yml; then
   echo "ERROR: Published multi-platform verification bypasses the isolated BuildKit emulator." >&2


### PR DESCRIPTION
Closes #3372

## Summary

- replace direct multi-architecture `docker run` verification with one BuildKit execution path
- pin verification to the content-addressed OCI index digest computed from the raw registry manifest
- verify architecture and `xcsh` version for both linux/amd64 and linux/arm64
- reject legacy direct-platform and YAML-ambiguous heredoc verification paths in the container contract

## Verification

- `bash scripts/tdd-docker.sh` (native image build, container contracts, credential-free UAT)
- exact YAML-extracted publication script against `ghcr.io/f5-sales-demo/xcsh:v20.22.0`: amd64 `x86_64`, arm64 `aarch64`, version `20.22.0`, digest `sha256:05aa56d948919f07d9cc7bdd059f19ec95dbd4854520dcb4494499f608454022`
- `bun run check:tools`
- `bun run check`
- `bun run lint`
- `bun run test` (all packages; xcsh 6,709 pass, 559 skip, 0 fail)
- `actionlint`, `yamllint`, `shellcheck`, `git diff --check`
- changed-scope PII enforcement clean
- independent Antigravity reviewer and verifier approved with zero findings