### PR TITLE
fix(ci): use canonical Docker trust gate name

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   trust-gate:
-    name: Verify same-repository trust boundary
+    name: Trust Docker-capable job
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || startsWith(github.ref, 'refs/tags/v'))) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
     permissions: {}

--- a/scripts/tdd-docker.sh
+++ b/scripts/tdd-docker.sh
@@ -104,6 +104,11 @@ if grep -Fq '/var/run/docker.sock' <<<"$compose_config"; then
   exit 1
 fi
 grep -Fq 'container-test:' .github/workflows/container.yml
+grep -Fq 'name: Trust Docker-capable job' .github/workflows/container.yml
+if grep -Fq 'name: Verify same-repository trust boundary' .github/workflows/container.yml; then
+  echo 'container workflow still uses the noncanonical Docker trust-gate name' >&2
+  exit 1
+fi
 grep -Fq 'runs-on: [self-hosted, Linux, X64, xcsh, container-build]' .github/workflows/container.yml
 grep -Fq 'docker/build-push-action@' .github/workflows/container.yml
 grep -Fq 'docker/setup-qemu-action@' .github/workflows/container.yml


### PR DESCRIPTION
## Summary

Aligns the xcsh container workflow with the governed fleet dispatcher’s single fail-closed Docker trust-gate contract. This is a clean break: the noncanonical name is removed, with no alias or compatibility recognition.

Closes #3378

## Changes

- Rename the socketless gate to `Trust Docker-capable job`.
- Assert the canonical name and reject the retired name in the focused container contract test.
- Leave runner policy, labels, and Docker privileges unchanged.

## Verification

- TDD red: the canonical-name assertion failed against `Verify same-repository trust boundary`.
- Green: canonical-name assertion and retired-name absence passed.
- `shfmt -d scripts/tdd-docker.sh`
- `shellcheck scripts/tdd-docker.sh`
- `actionlint .github/workflows/container.yml`
- `git diff --check origin/main...HEAD`

## Delivery

- Fresh branch from `origin/main` at `908610235`.
- Exact commit: `7a78b849c`.
- The repair was discovered by following PR #3377’s first post-refactor CI cascade.