### PR TITLE
fix(natives): resolve ARM64 compiler paths

### DIFF
--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Built Linux GNU release addons against the GLIBC 2.17 napi-rs cross-toolchain floor and added
   artifact plus Debian 12 installation gates
   ([#3376](https://github.com/f5-sales-demo/xcsh/issues/3376)).
+- Resolved the ARM64 C/C++ compiler paths before invoking napi-rs so the release build does not
+  depend on a bare compiler name remaining on `PATH`
+  ([#3381](https://github.com/f5-sales-demo/xcsh/issues/3381)).
 
 ## [20.3.0] - 2026-08-04
 

--- a/packages/natives/scripts/build-native.ts
+++ b/packages/natives/scripts/build-native.ts
@@ -61,8 +61,15 @@ function resolveReleaseLinuxTarget(): string | null {
 
 const releaseLinuxTarget = resolveReleaseLinuxTarget();
 if (releaseLinuxTarget === "aarch64-unknown-linux-gnu") {
-	Bun.env.TARGET_CC = "clang";
-	Bun.env.TARGET_CXX = "clang++";
+	const targetCc = Bun.which("clang");
+	const targetCxx = Bun.which("clang++");
+	if (!targetCc || !targetCxx) {
+		throw new Error(
+			"Linux ARM64 release builds require clang and clang++; install them on the build runner before invoking napi-rs.",
+		);
+	}
+	Bun.env.TARGET_CC = targetCc;
+	Bun.env.TARGET_CXX = targetCxx;
 	Bun.env.CFLAGS_aarch64_unknown_linux_gnu = "-D_BSD_SOURCE";
 }
 

--- a/packages/natives/test/build-safety.test.ts
+++ b/packages/natives/test/build-safety.test.ts
@@ -56,12 +56,15 @@ describe("native build safety", () => {
 			expect(findGlibcRequirementsAbove(readelf, "2.17")).toEqual([]);
 		});
 
-		it("configures Linux CI builds with the napi cross toolchain and no host linker override", async () => {
+		it("configures Linux CI builds with resolved ARM64 compilers, the napi cross toolchain, and no host linker override", async () => {
 			const build = await Bun.file(new URL("../scripts/build-native.ts", import.meta.url)).text();
 			const workflow = await Bun.file(new URL("../../../.github/workflows/ci.yml", import.meta.url)).text();
 			expect(build).toContain('napiArgs.push("--target", releaseLinuxTarget, "--use-napi-cross")');
-			expect(build).toContain('Bun.env.TARGET_CC = "clang"');
-			expect(build).toContain('Bun.env.TARGET_CXX = "clang++"');
+			expect(build).toContain('const targetCc = Bun.which("clang");');
+			expect(build).toContain('const targetCxx = Bun.which("clang++");');
+			expect(build).toContain("if (!targetCc || !targetCxx)");
+			expect(build).toContain("Bun.env.TARGET_CC = targetCc;");
+			expect(build).toContain("Bun.env.TARGET_CXX = targetCxx;");
 			expect(build).toContain('Bun.env.CFLAGS_aarch64_unknown_linux_gnu = "-D_BSD_SOURCE"');
 			expect(workflow).not.toContain("CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER");
 		});


### PR DESCRIPTION
## Summary

- resolve Linux ARM64 clang and clang++ to absolute paths before invoking napi-rs
- fail clearly when the required compiler pair is unavailable
- retain the explicit GLIBC 2.17 cross-toolchain contract, with no legacy compiler fallback
- cover the resolved-compiler contract and document the release fix

Closes #3381

## Verification

- `bun test packages/natives/test/build-safety.test.ts` (10 pass)
- `bun run check:tools`
- `bun run lint`
- `bun run check`
- `CI=true CROSS_TARGET=aarch64-unknown-linux-gnu TARGET_PLATFORM=linux TARGET_ARCH=arm64 RUST_TARGET=aarch64-unknown-linux-gnu bun run ci:build:native`
- `PI_NATIVE_EXPECTED_ADDONS=linux-arm64 bun scripts/ci-release-verify-natives.ts` (AArch64 ELF, GLIBC <= 2.17, symbols clean)
- `git diff --check`

The failed source run was https://github.com/f5-sales-demo/xcsh/actions/runs/32860070622/job/97850290326; it could not resolve bare `clang` inside the napi cross-toolchain environment.