### PR TITLE
ci(runners): migrate xcsh workflows to ARC

### DIFF
--- a/.github/workflows/arc-compatibility.yml
+++ b/.github/workflows/arc-compatibility.yml
@@ -1,0 +1,129 @@
+---
+name: ARC Compatibility
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: arc-compatibility-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  socketless:
+    name: Socketless toolchain and native builds
+    runs-on: xcsh-socketless
+    timeout-minutes: 45
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          lfs: true
+
+      - name: Prove Docker is absent
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -z "${DOCKER_HOST:-}"
+          container_cli=$(printf '%s%s' dock er)
+          if command -v "$container_cli" >/dev/null 2>&1; then
+            echo "Docker CLI must be absent from the socketless profile" >&2
+            exit 1
+          fi
+          test ! -S /run/docker.sock
+
+      - name: Set up Bun 1.3
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          no-cache: true
+          bun-version: "1.3"
+
+      - name: Install Rust and ARM64 target
+        uses: ./.github/actions/setup-rust
+        with:
+          target: aarch64-unknown-linux-gnu
+
+      - name: Set up Zig 0.15.2
+        uses: ./.github/actions/setup-zig
+
+      - name: Install workspace dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Verify compiler toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          bun --version
+          rustup show active-toolchain
+          rustc --version
+          cargo --version
+          zig version
+          clang --version
+          clang++ --version
+
+      - name: Build native Linux x64 addon
+        run: TARGET_PLATFORM=linux TARGET_ARCH=x64 TARGET_VARIANTS=baseline bun run ci:build:native
+
+      - name: Cross-compile native Linux ARM64 addon
+        run: CROSS_TARGET=aarch64-unknown-linux-gnu TARGET_PLATFORM=linux TARGET_ARCH=arm64 bun run ci:build:native
+
+  container:
+    name: Container toolchain and compatibility checks
+    runs-on: xcsh-container-build
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Validate ARC DinD endpoint
+        shell: bash
+        run: |
+          set -euo pipefail
+          : "${DOCKER_HOST:?ARC DinD must provide DOCKER_HOST}"
+          case "$DOCKER_HOST" in
+            unix:///*) ;;
+            *)
+              echo "DOCKER_HOST must use a Unix socket: $DOCKER_HOST" >&2
+              exit 1
+              ;;
+          esac
+          docker_socket=${DOCKER_HOST#unix://}
+          test "$docker_socket" != /run/docker.sock
+          test -S "$docker_socket"
+          docker version
+          docker buildx version
+          docker compose version
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+        with:
+          driver: docker-container
+          name: xcsh-arc-compatibility
+          use: true
+          cleanup: true
+
+      - name: Build and inspect a scratch image
+        shell: bash
+        run: |
+          set -euo pipefail
+          image="xcsh-arc-compatibility-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          cleanup() { docker image rm --force "$image" >/dev/null 2>&1 || true; }
+          trap cleanup EXIT
+          printf 'FROM scratch\n' | docker build --tag "$image" -
+          docker image inspect "$image"
+
+      - name: Verify published npm package on Debian 12
+        shell: bash
+        run: |
+          set -euo pipefail
+          EXPECTED_VERSION=$(jq -r .version packages/coding-agent/package.json)
+          export EXPECTED_VERSION
+          bash scripts/ci-verify-npm-debian.sh
+
+      - name: Run mocked Podman UAT harness
+        run: bash scripts/test-uat-podman-arm64.sh

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -31,7 +31,7 @@ jobs:
       github.event.pull_request.draft == false &&
       github.actor != 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
+    runs-on: xcsh-socketless
     steps:
       - name: Require downstream-triggering token
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
   check:
     name: check
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
+    runs-on: xcsh-socketless
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -123,7 +123,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-24.04
-            runner: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
+            runner: xcsh-socketless
           - os: macos-15-intel
             runner: macos-15-intel
           - os: macos-14
@@ -149,17 +149,17 @@ jobs:
       fail-fast: false
       matrix:
         include: ${{ startsWith(github.ref, 'refs/tags/v') && fromJSON('[
-          {"os":"ubuntu-24.04","runner":["self-hosted","Linux","X64","xcsh","ubuntu-24.04"],"platform":"linux","arch":"x64","variants":"baseline","rust_checks":true,"sandbox_check":true},
-          {"os":"ubuntu-24.04","runner":["self-hosted","Linux","X64","xcsh","ubuntu-24.04"],"platform":"linux","arch":"x64","variants":"modern"},
-          {"os":"ubuntu-24.04","runner":["self-hosted","Linux","X64","xcsh","ubuntu-24.04"],"platform":"linux","arch":"arm64","target":"aarch64-unknown-linux-gnu"},
+          {"os":"ubuntu-24.04","runner":"xcsh-socketless","platform":"linux","arch":"x64","variants":"baseline","rust_checks":true,"sandbox_check":true},
+          {"os":"ubuntu-24.04","runner":"xcsh-socketless","platform":"linux","arch":"x64","variants":"modern"},
+          {"os":"ubuntu-24.04","runner":"xcsh-socketless","platform":"linux","arch":"arm64","target":"aarch64-unknown-linux-gnu"},
           {"os":"macos-15-intel","platform":"darwin","arch":"x64","variants":"baseline"},
           {"os":"macos-15-intel","platform":"darwin","arch":"x64","variants":"modern"},
           {"os":"macos-14","platform":"darwin","arch":"arm64","sandbox_check":true},
           {"os":"windows-latest","platform":"win32","arch":"x64","variants":"baseline"},
           {"os":"windows-latest","platform":"win32","arch":"x64","variants":"modern"}
           ]') || fromJSON('[
-          {"os":"ubuntu-24.04","runner":["self-hosted","Linux","X64","xcsh","ubuntu-24.04"],"platform":"linux","arch":"x64","variants":"baseline","rust_checks":true,"sandbox_check":true},
-          {"os":"ubuntu-24.04","runner":["self-hosted","Linux","X64","xcsh","ubuntu-24.04"],"platform":"linux","arch":"x64","variants":"modern"},
+          {"os":"ubuntu-24.04","runner":"xcsh-socketless","platform":"linux","arch":"x64","variants":"baseline","rust_checks":true,"sandbox_check":true},
+          {"os":"ubuntu-24.04","runner":"xcsh-socketless","platform":"linux","arch":"x64","variants":"modern"},
           {"os":"macos-14","platform":"darwin","arch":"arm64","sandbox_check":true}
           ]') }}
     runs-on: ${{ matrix.runner || matrix.os }}
@@ -288,7 +288,7 @@ jobs:
   test:
     name: test
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
+    runs-on: xcsh-socketless
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -393,7 +393,7 @@ jobs:
   install_methods:
     name: Test installation methods
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
+    runs-on: xcsh-socketless
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -483,7 +483,7 @@ jobs:
     environment: release
     name: Invalidate stale release pull requests
     if: github.ref == 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'chore:')
-    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
+    runs-on: xcsh-socketless
     timeout-minutes: 5
     permissions: {}
     steps:
@@ -506,7 +506,7 @@ jobs:
     name: Prepare automatic release
     if: github.ref == 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'chore:')
     needs: [check, native, test, install_methods]
-    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
+    runs-on: xcsh-socketless
     permissions: {}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -595,7 +595,7 @@ jobs:
     name: Build Linux and Windows release
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [check, native, test, install_methods]
-    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
+    runs-on: xcsh-socketless
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1037,7 +1037,7 @@ jobs:
     name: Publish immutable GitHub release
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [build-release, build-sign-macos]
-    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
+    runs-on: xcsh-socketless
     permissions: {}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1100,7 +1100,7 @@ jobs:
     name: Publish Homebrew formula
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [create-release]
-    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
+    runs-on: xcsh-socketless
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1260,7 +1260,7 @@ jobs:
     name: Publish npm packages
     if: startsWith(github.ref, 'refs/tags/v') && !inputs.skip_npm
     needs: [create-release]
-    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
+    runs-on: xcsh-socketless
     env:
       XCSH_BUILD_BRANCH: main
     permissions:
@@ -1368,7 +1368,7 @@ jobs:
     name: Verify npm installation
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [publish-npm]
-    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
+    runs-on: xcsh-socketless
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1444,11 +1444,21 @@ jobs:
           EXPECTED_VERSION: ${{ github.ref_name }}
         run: bash scripts/ci-verify-npm-install.sh
 
+  trust-gate:
+    name: Trust Docker-capable job
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: verify-npm-install
+    runs-on: xcsh-socketless
+    permissions: {}
+    steps:
+      - name: Confirm this runner has no Docker socket
+        run: test ! -S /run/docker.sock
+
   verify-npm-debian:
     name: Verify npm installation on Debian 12
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [verify-npm-install]
-    runs-on: [self-hosted, Linux, X64, xcsh, container-build]
+    needs: [verify-npm-install, trust-gate]
+    runs-on: xcsh-container-build
     permissions:
       contents: read
     steps:

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -18,7 +18,7 @@ jobs:
   trust-gate:
     name: Trust Docker-capable job
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || startsWith(github.ref, 'refs/tags/v'))) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
-    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
+    runs-on: xcsh-socketless
     permissions: {}
     steps:
       - name: Confirm this runner has no Docker socket
@@ -28,7 +28,7 @@ jobs:
     name: container-build (native-amd64)
     needs: trust-gate
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || startsWith(github.ref, 'refs/tags/v'))) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
-    runs-on: [self-hosted, Linux, X64, xcsh, container-build]
+    runs-on: xcsh-container-build
     timeout-minutes: 30
     permissions:
       contents: read
@@ -54,7 +54,7 @@ jobs:
     name: podman-uat-harness
     needs: trust-gate
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || startsWith(github.ref, 'refs/tags/v'))) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
-    runs-on: [self-hosted, Linux, X64, xcsh, container-build]
+    runs-on: xcsh-container-build
     timeout-minutes: 5
     permissions:
       contents: read
@@ -71,7 +71,7 @@ jobs:
     name: container-test
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || startsWith(github.ref, 'refs/tags/v'))) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     needs: [trust-gate, container-build, podman-uat-harness]
-    runs-on: [self-hosted, Linux, X64, xcsh, container-build]
+    runs-on: xcsh-container-build
     timeout-minutes: 5
     steps:
       - name: Require architecture and harness tests
@@ -86,7 +86,7 @@ jobs:
     name: publish-ghcr
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [container-test]
-    runs-on: [self-hosted, Linux, X64, xcsh, container-build]
+    runs-on: xcsh-container-build
     timeout-minutes: 180
     permissions:
       contents: read

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   auto-merge:
     name: Approve and enable auto-merge
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
+    runs-on: xcsh-socketless
     permissions:
       contents: write # merge validated Dependabot updates
       pull-requests: write # approve pull requests and enable auto-merge

--- a/.github/workflows/self-hosted-runner-cache-smoke.yml
+++ b/.github/workflows/self-hosted-runner-cache-smoke.yml
@@ -16,7 +16,7 @@ jobs:
   trust-gate:
     name: Verify same-repository trust boundary
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
-    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
+    runs-on: xcsh-socketless
     permissions: {}
     steps:
       - name: Confirm this runner has no Docker socket
@@ -26,16 +26,26 @@ jobs:
     needs: trust-gate
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     name: Validate container-build Docker route
-    runs-on: [self-hosted, Linux, X64, xcsh, container-build]
+    runs-on: xcsh-container-build
     timeout-minutes: 5
     steps:
-      - name: Build and inspect a scratch image through the Docker socket
+      - name: Build and inspect a scratch image through ARC DinD
         shell: bash
         run: |
           set -euo pipefail
-          test -S /run/docker.sock
-          : "${DOCKER_HOST:=unix:///run/docker.sock}"
-          export DOCKER_HOST
+          : "${DOCKER_HOST:?ARC DinD must provide DOCKER_HOST}"
+          case "$DOCKER_HOST" in
+            unix:///*) ;;
+            *)
+              echo "DOCKER_HOST must use a Unix socket: $DOCKER_HOST" >&2
+              exit 1
+              ;;
+          esac
+
+          docker_socket=${DOCKER_HOST#unix://}
+          test "$docker_socket" != /run/docker.sock
+          test -S "$docker_socket"
+
           docker version
           docker buildx version
           docker compose version

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   semgrep:
     name: Semgrep SAST
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
+    runs-on: xcsh-socketless
     permissions:
       contents: read # checkout the source to scan
       security-events: write # upload SARIF to Code Scanning

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -16,7 +16,7 @@ jobs:
   linked-issue:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     name: Check linked issues
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
+    runs-on: xcsh-socketless
     permissions:
       pull-requests: read # query this event's exact PR and its closing issue references
     steps:

--- a/.github/workflows/tag-on-version-bump.yml
+++ b/.github/workflows/tag-on-version-bump.yml
@@ -48,7 +48,7 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       startsWith(github.event.head_commit.message, 'chore: bump version to v')
-    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
+    runs-on: xcsh-socketless
     permissions: {}
     steps:
       - name: Checkout

--- a/.github/workflows/translation-audit.yml
+++ b/.github/workflows/translation-audit.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   audit:
     name: English-only documentation policy
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
+    runs-on: xcsh-socketless
     steps:
       - name: Record suspended translation policy
         run: |

--- a/.github/workflows/workflow-security-audit.yml
+++ b/.github/workflows/workflow-security-audit.yml
@@ -85,7 +85,7 @@ jobs:
   audit:
     name: Audit workflows (zizmor)
     if: github.event_name != 'pull_request'
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
+    runs-on: xcsh-socketless
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/packages/coding-agent/test/scripts/arc-runner-workflow-contract.test.ts
+++ b/packages/coding-agent/test/scripts/arc-runner-workflow-contract.test.ts
@@ -1,0 +1,225 @@
+import { expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { readdir } from "node:fs/promises";
+import * as path from "node:path";
+import { parse } from "yaml";
+
+interface WorkflowStep {
+	run?: unknown;
+	uses?: unknown;
+}
+
+interface WorkflowJob {
+	if?: unknown;
+	"runs-on"?: unknown;
+	needs?: unknown;
+	steps?: WorkflowStep[];
+}
+
+interface WorkflowDocument {
+	jobs?: Record<string, WorkflowJob>;
+	permissions?: unknown;
+}
+
+interface LoadedWorkflow {
+	document: WorkflowDocument;
+	path: string;
+	source: string;
+}
+
+const REPOSITORY_ROOT = path.resolve(import.meta.dir, "../../../..");
+const WORKFLOW_ROOT = path.join(REPOSITORY_ROOT, ".github/workflows");
+const WORKFLOW_DIRECTORIES = [
+	WORKFLOW_ROOT,
+	path.join(REPOSITORY_ROOT, ".github/workflows-disabled"),
+	path.join(REPOSITORY_ROOT, ".github/disabled-workflows"),
+];
+const CACHE_SMOKE_WORKFLOW = path.join(WORKFLOW_ROOT, "self-hosted-runner-cache-smoke.yml");
+const COMPATIBILITY_WORKFLOW = path.join(WORKFLOW_ROOT, "arc-compatibility.yml");
+
+async function collectYamlFiles(directory: string): Promise<string[]> {
+	if (!existsSync(directory)) return [];
+
+	const files: string[] = [];
+	for (const entry of await readdir(directory, { withFileTypes: true })) {
+		const candidate = path.join(directory, entry.name);
+		if (entry.isDirectory()) {
+			files.push(...(await collectYamlFiles(candidate)));
+		} else if (/\.ya?ml$/.test(entry.name)) {
+			files.push(candidate);
+		}
+	}
+	return files.sort();
+}
+
+async function loadWorkflowInventory(): Promise<LoadedWorkflow[]> {
+	const paths = (await Promise.all(WORKFLOW_DIRECTORIES.map(collectYamlFiles))).flat().sort();
+	return await Promise.all(
+		paths.map(async workflowPath => {
+			const source = await Bun.file(workflowPath).text();
+			return {
+				document: parse(source) as WorkflowDocument,
+				path: path.relative(REPOSITORY_ROOT, workflowPath),
+				source,
+			};
+		}),
+	);
+}
+
+function embeddedMatrixRows(source: string): Array<Record<string, unknown>> {
+	const rows: Array<Record<string, unknown>> = [];
+	for (const match of source.matchAll(/fromJSON\('(\[[\s\S]*?\])'\)/g)) {
+		const parsed = JSON.parse(match[1] ?? "null");
+		if (!Array.isArray(parsed)) throw new Error("fromJSON workflow matrix must be an array");
+		for (const value of parsed) {
+			if (typeof value !== "object" || value === null || Array.isArray(value)) {
+				throw new Error("fromJSON workflow matrix row must be an object");
+			}
+			rows.push(value as Record<string, unknown>);
+		}
+	}
+	return rows;
+}
+
+function jobUsesDocker(job: WorkflowJob): boolean {
+	return (
+		job.steps?.some(step => {
+			if (typeof step.uses === "string" && step.uses.startsWith("docker/")) return true;
+			if (typeof step.run !== "string") return false;
+			return (
+				/^\s*docker(?:\s|$)/m.test(step.run) || /scripts\/(?:tdd-docker|ci-verify-npm-debian)\.sh/.test(step.run)
+			);
+		}) ?? false
+	);
+}
+
+test("all workflow inventories reject retired xcsh label arrays, including embedded matrices", async () => {
+	const workflows = await loadWorkflowInventory();
+	const retiredRoutes = [
+		["self-hosted", "Linux", "X64", "xcsh", "ubuntu-24.04"],
+		["self-hosted", "Linux", "X64", "xcsh", "container-build"],
+	];
+	const observedArcRoutes = new Set<string>();
+
+	expect(workflows.length).toBeGreaterThan(0);
+	for (const workflow of workflows) {
+		for (const job of Object.values(workflow.document.jobs ?? {})) {
+			const route = job["runs-on"];
+			if (typeof route === "string" && route.startsWith("xcsh-")) observedArcRoutes.add(route);
+			for (const retiredRoute of retiredRoutes) expect(route, workflow.path).not.toEqual(retiredRoute);
+		}
+		for (const row of embeddedMatrixRows(workflow.source)) {
+			const route = row.runner;
+			if (typeof route === "string" && route.startsWith("xcsh-")) observedArcRoutes.add(route);
+			for (const retiredRoute of retiredRoutes) expect(route, workflow.path).not.toEqual(retiredRoute);
+			if (row.os === "ubuntu-24.04" && route !== undefined) {
+				expect(route, workflow.path).toBe("xcsh-socketless");
+			}
+		}
+	}
+
+	expect(observedArcRoutes).toEqual(new Set(["xcsh-container-build", "xcsh-socketless"]));
+});
+
+test("Docker consumers use the container pool and every trust gate is socketless", async () => {
+	const workflows = await loadWorkflowInventory();
+	const trustGates: string[] = [];
+	const dockerConsumers: string[] = [];
+
+	for (const workflow of workflows) {
+		for (const [jobId, job] of Object.entries(workflow.document.jobs ?? {})) {
+			const location = `${workflow.path}:${jobId}`;
+			if (jobId === "trust-gate") {
+				trustGates.push(location);
+				expect(job["runs-on"], location).toBe("xcsh-socketless");
+				continue;
+			}
+			if (jobUsesDocker(job)) {
+				dockerConsumers.push(location);
+				expect(job["runs-on"], location).toBe("xcsh-container-build");
+			}
+		}
+	}
+
+	expect(trustGates.sort()).toEqual([
+		".github/workflows/ci.yml:trust-gate",
+		".github/workflows/container.yml:trust-gate",
+		".github/workflows/self-hosted-runner-cache-smoke.yml:trust-gate",
+	]);
+	expect(dockerConsumers).toContain(".github/workflows/ci.yml:verify-npm-debian");
+	expect(dockerConsumers).toContain(".github/workflows/container.yml:container-build");
+	expect(dockerConsumers).toContain(".github/workflows/container.yml:publish-ghcr");
+	expect(dockerConsumers).toContain(".github/workflows/self-hosted-runner-cache-smoke.yml:container-build-smoke");
+	expect(dockerConsumers).toContain(".github/workflows/arc-compatibility.yml:container");
+});
+
+test("repository-specific managed callers use the socketless ARC route", async () => {
+	const expectedJobs: Record<string, string[]> = {
+		"auto-merge.yml": ["require-token"],
+		"dependabot-auto-merge.yml": ["auto-merge"],
+		"semgrep.yml": ["semgrep"],
+		"super-linter.yml": ["linked-issue"],
+		"translation-audit.yml": ["audit"],
+		"workflow-security-audit.yml": ["audit"],
+	};
+
+	for (const [workflowName, jobIds] of Object.entries(expectedJobs)) {
+		const document = parse(await Bun.file(path.join(WORKFLOW_ROOT, workflowName)).text()) as WorkflowDocument;
+		for (const jobId of jobIds) {
+			expect(document.jobs?.[jobId]?.["runs-on"], `${workflowName}:${jobId}`).toBe("xcsh-socketless");
+		}
+	}
+});
+
+test("cache smoke requires and validates the ARC-provided Unix Docker endpoint", async () => {
+	const source = await Bun.file(CACHE_SMOKE_WORKFLOW).text();
+
+	expect(source).toMatch(/\$\{DOCKER_HOST:\?ARC DinD must provide DOCKER_HOST\}/);
+	expect(source).toMatch(/\$\{DOCKER_HOST#unix:\/\/\}/);
+	expect(source).toContain('test -S "$docker_socket"');
+	expect(source).toContain('test "$docker_socket" != /run/docker.sock');
+	expect(source).not.toContain("${DOCKER_HOST:=");
+	expect(source).toContain("docker version");
+	expect(source).toContain("docker buildx version");
+	expect(source).toContain("docker compose version");
+	expect(source).toContain("docker build --tag");
+	expect(source).toContain('docker image inspect "$image"');
+});
+
+test("release Docker jobs remain tag-only and preserve their release dependencies", async () => {
+	const releaseCondition = "startsWith(github.ref, 'refs/tags/v')";
+	const containerWorkflow = parse(
+		await Bun.file(path.join(WORKFLOW_ROOT, "container.yml")).text(),
+	) as WorkflowDocument;
+	const ciWorkflow = parse(await Bun.file(path.join(WORKFLOW_ROOT, "ci.yml")).text()) as WorkflowDocument;
+
+	expect(containerWorkflow.jobs?.["publish-ghcr"]?.if).toBe(releaseCondition);
+	expect(containerWorkflow.jobs?.["publish-ghcr"]?.needs).toEqual(["container-test"]);
+	expect(ciWorkflow.jobs?.["trust-gate"]?.if).toBe(releaseCondition);
+	expect(ciWorkflow.jobs?.["trust-gate"]?.needs).toBe("verify-npm-install");
+	expect(ciWorkflow.jobs?.["verify-npm-debian"]?.if).toBe(releaseCondition);
+	expect(ciWorkflow.jobs?.["verify-npm-debian"]?.needs).toEqual(["verify-npm-install", "trust-gate"]);
+});
+
+test("manual ARC compatibility covers both profiles without publication mutation", async () => {
+	const source = await Bun.file(COMPATIBILITY_WORKFLOW).text();
+	const workflow = parse(source) as WorkflowDocument;
+
+	expect(workflow.jobs?.socketless?.["runs-on"]).toBe("xcsh-socketless");
+	expect(workflow.jobs?.container?.["runs-on"]).toBe("xcsh-container-build");
+	expect(source).toContain("oven-sh/setup-bun@");
+	expect(source).toContain("uses: ./.github/actions/setup-rust");
+	expect(source).toContain("uses: ./.github/actions/setup-zig");
+	expect(source).toContain("aarch64-unknown-linux-gnu");
+	expect(source).toContain("TARGET_ARCH=x64");
+	expect(source).toContain("TARGET_ARCH=arm64");
+	expect(source).toMatch(/\$\{DOCKER_HOST:\?ARC DinD must provide DOCKER_HOST\}/);
+	expect(source).toContain("docker buildx version");
+	expect(source).toContain("docker compose version");
+	expect(source).toContain("scripts/ci-verify-npm-debian.sh");
+	expect(source).toContain("scripts/test-uat-podman-arm64.sh");
+	expect(source).not.toMatch(
+		/docker\/login-action|docker\/build-push-action|npm publish|gh release|git tag|push: true/,
+	);
+	expect(workflow.permissions).toEqual({ contents: "read" });
+});

--- a/scripts/tdd-docker.sh
+++ b/scripts/tdd-docker.sh
@@ -52,6 +52,79 @@ cleanup() {
 }
 trap cleanup EXIT
 
+workflow_roots=(.github/workflows)
+for candidate in .github/workflows-disabled .github/disabled-workflows; do
+  if [[ -d "$candidate" ]]; then
+    workflow_roots+=("$candidate")
+  fi
+done
+mapfile -d '' workflow_files < <(
+  find "${workflow_roots[@]}" -type f \( -name '*.yml' -o -name '*.yaml' \) -print0
+)
+test "${#workflow_files[@]}" -gt 0
+
+for workflow_file in "${workflow_files[@]}"; do
+  compact=$(tr -d '[:space:]' <"$workflow_file")
+  for retired_route in '[self-hosted,Linux,X64,xcsh,ubuntu-24.04]' '["self-hosted","Linux","X64","xcsh","ubuntu-24.04"]' '[self-hosted,Linux,X64,xcsh,container-build]' '["self-hosted","Linux","X64","xcsh","container-build"]'; do
+    if [[ "$compact" == *"$retired_route"* ]]; then
+      echo "ERROR: $workflow_file contains retired runner route $retired_route" >&2
+      exit 1
+    fi
+  done
+done
+grep -Fq 'runs-on: xcsh-socketless' "${workflow_files[@]}"
+grep -Fq 'runs-on: xcsh-container-build' "${workflow_files[@]}"
+
+job_block() {
+  local workflow_file=$1
+  local job_id=$2
+  awk -v marker="  ${job_id}:" '
+    $0 == marker { capture = 1; next }
+    capture && /^  [A-Za-z0-9_-]+:/ { exit }
+    capture { print }
+  ' "$workflow_file"
+}
+
+assert_job_route() {
+  local workflow_file=$1
+  local job_id=$2
+  local expected_route=$3
+  if ! job_block "$workflow_file" "$job_id" | grep -Fxq "    runs-on: $expected_route"; then
+    echo "ERROR: $workflow_file job $job_id must use $expected_route" >&2
+    exit 1
+  fi
+}
+
+for workflow_file in .github/workflows/ci.yml .github/workflows/container.yml .github/workflows/self-hosted-runner-cache-smoke.yml; do
+  assert_job_route "$workflow_file" trust-gate xcsh-socketless
+done
+for job_id in container-build podman-uat-harness container-test publish-ghcr; do
+  assert_job_route .github/workflows/container.yml "$job_id" xcsh-container-build
+done
+assert_job_route .github/workflows/ci.yml verify-npm-debian xcsh-container-build
+assert_job_route .github/workflows/self-hosted-runner-cache-smoke.yml container-build-smoke xcsh-container-build
+assert_job_route .github/workflows/arc-compatibility.yml socketless xcsh-socketless
+assert_job_route .github/workflows/arc-compatibility.yml container xcsh-container-build
+assert_job_route .github/workflows/auto-merge.yml require-token xcsh-socketless
+assert_job_route .github/workflows/dependabot-auto-merge.yml auto-merge xcsh-socketless
+assert_job_route .github/workflows/semgrep.yml semgrep xcsh-socketless
+assert_job_route .github/workflows/super-linter.yml linked-issue xcsh-socketless
+assert_job_route .github/workflows/translation-audit.yml audit xcsh-socketless
+assert_job_route .github/workflows/workflow-security-audit.yml audit xcsh-socketless
+
+cache_smoke=.github/workflows/self-hosted-runner-cache-smoke.yml
+grep -Fq ': "${DOCKER_HOST:?ARC DinD must provide DOCKER_HOST}"' "$cache_smoke"
+grep -Fq 'docker_socket=${DOCKER_HOST#unix://}' "$cache_smoke"
+grep -Fq 'test "$docker_socket" != /run/docker.sock' "$cache_smoke"
+grep -Fq 'test -S "$docker_socket"' "$cache_smoke"
+if grep -Fq '${DOCKER_HOST:=' "$cache_smoke"; then
+  echo "ERROR: cache smoke must not synthesize a Docker endpoint" >&2
+  exit 1
+fi
+if grep -Eq 'docker/login-action|docker/build-push-action|npm publish|gh release|git tag|push:[[:space:]]*true' .github/workflows/arc-compatibility.yml; then
+  echo "ERROR: ARC compatibility workflow must not mutate a release or registry" >&2
+  exit 1
+fi
 docker info >/dev/null 2>&1 || {
   echo "ERROR: Docker is unavailable." >&2
   exit 1
@@ -109,7 +182,7 @@ if grep -Fq 'name: Verify same-repository trust boundary' .github/workflows/cont
   echo 'container workflow still uses the noncanonical Docker trust-gate name' >&2
   exit 1
 fi
-grep -Fq 'runs-on: [self-hosted, Linux, X64, xcsh, container-build]' .github/workflows/container.yml
+grep -Fq 'runs-on: xcsh-container-build' .github/workflows/container.yml
 grep -Fq 'docker/build-push-action@' .github/workflows/container.yml
 grep -Fq 'docker/setup-qemu-action@' .github/workflows/container.yml
 grep -Fq 'platforms: linux/amd64,linux/arm64' .github/workflows/container.yml


### PR DESCRIPTION
## Summary

- route Linux workflows to the repository-scoped ARC socketless and container-build scale sets
- add a manual compatibility pilot for native, cross-compile, Docker, Debian npm, and mocked Podman paths
- strengthen workflow contracts and Docker socket smoke coverage

## Validation

- ARC workflow contract: 6 tests, 170 assertions
- actionlint, ShellCheck, zizmor, governed workflow validator, and runner auditor
- bun check/lint and full workspace test suite
- Docker UAT plus mocked ARM64 Podman harness
- direct AGY reviewer and verifier: approved with zero findings

Closes #3384