### PR TITLE
ci(runners): pass ARC labels to Super-Linter

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -47,9 +47,11 @@ jobs:
     needs: linked-issue
     # No `secrets:` — least privilege. The reusable uses only the automatic
     # GITHUB_TOKEN, so passing repository secrets would over-provision it.
-    uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@4e612d17a780ebc5299732eafb93d506e122e337
+    uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@b68cf1496e1a695751efee5114ddfe24f7cd9e35
     with:
       classify_xc_minimum_configs: ${{ github.repository == 'f5-sales-demo/terraform-provider-xcsh' }}
+      socketless_runner_label: xcsh-socketless
+      container_build_runner_label: xcsh-container-build
     permissions:
       contents: read # checkout repository content in the reusable workflow
       packages: read # pull lint tooling from GitHub Packages

--- a/scripts/tdd-docker.sh
+++ b/scripts/tdd-docker.sh
@@ -109,6 +109,8 @@ assert_job_route .github/workflows/auto-merge.yml require-token xcsh-socketless
 assert_job_route .github/workflows/dependabot-auto-merge.yml auto-merge xcsh-socketless
 assert_job_route .github/workflows/semgrep.yml semgrep xcsh-socketless
 assert_job_route .github/workflows/super-linter.yml linked-issue xcsh-socketless
+grep -Fq 'socketless_runner_label: xcsh-socketless' .github/workflows/super-linter.yml
+grep -Fq 'container_build_runner_label: xcsh-container-build' .github/workflows/super-linter.yml
 assert_job_route .github/workflows/translation-audit.yml audit xcsh-socketless
 assert_job_route .github/workflows/workflow-security-audit.yml audit xcsh-socketless
 


### PR DESCRIPTION
## Summary

- pin the shared Super-Linter caller to the merged ARC-input interface
- pass the policy-approved xcsh-socketless and xcsh-container-build labels together
- extend the runner contract test for both reusable-workflow inputs

## Validation

- actionlint
- governed runner workflow audit
- changed-file pre-commit suite

Antigravity remains disabled and was not invoked.

Closes #3394