### PR TITLE
fix(ci): restore Pages ARC labels

### DIFF
--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -21,6 +21,8 @@ jobs:
     uses: f5-sales-demo/docs-control/.github/workflows/github-pages-deploy.yml@b68cf1496e1a695751efee5114ddfe24f7cd9e35
     with:
       content-ref: ${{ github.sha }}
+      socketless_runner_label: xcsh-socketless
+      container_build_runner_label: xcsh-container-build
     permissions:
       contents: read # read documentation sources
       packages: read # pull the fleet documentation builder image


### PR DESCRIPTION
Closes #3407

Restore the exact xcsh-socketless and xcsh-container-build inputs on the custom Pages wrapper after managed reconciliation removed them. The paired docs-control governance change opts this wrapper out of future overwrites.

Validation:
- runner workflow auditor
- actionlint
- changed-scope PII enforcement

No AGY/A2A review was invoked.