### PR TITLE
fix(ai): recover incomplete streams and render nested arrays

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -780,9 +780,11 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 					let sawEvent = false;
 					let sawMessageStart = false;
 					let sawTerminalEnvelope = false;
+					let lastEnvelopeEvent = "none";
 
 					for await (const event of markFirstStreamEvent(anthropicStream, firstEventWatchdog)) {
 						sawEvent = true;
+						lastEnvelopeEvent = event.type;
 
 						if (event.type === "message_start") {
 							if (sawMessageStart) {
@@ -1040,7 +1042,19 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 						throw createAnthropicStreamEnvelopeError("stream ended before message_start");
 					}
 					if (!sawTerminalEnvelope) {
-						throw createAnthropicStreamEnvelopeError("stream ended before terminal stop signal");
+						throw createAnthropicStreamEnvelopeError(
+							"stream ended before terminal stop signal (provider=" +
+								model.provider +
+								", model=" +
+								model.id +
+								", api=" +
+								output.api +
+								", responseId=" +
+								(output.responseId ?? "unavailable") +
+								", lastEvent=" +
+								lastEnvelopeEvent +
+								")",
+						);
 					}
 
 					if (output.stopReason === "aborted" || output.stopReason === "error") {

--- a/packages/ai/test/anthropic-stream-envelope.test.ts
+++ b/packages/ai/test/anthropic-stream-envelope.test.ts
@@ -259,6 +259,10 @@ describe("anthropic stream envelope handling", () => {
 		expect(result.stopReason).toBe("error");
 		expect(result.errorMessage).toContain("stream ended before terminal stop signal");
 
+		expect(result.errorMessage).toContain("provider=anthropic");
+		expect(result.errorMessage).toContain("model=claude-sonnet-4-5");
+		expect(result.errorMessage).toContain("responseId=msg_tool_broken");
+		expect(result.errorMessage).toContain("lastEvent=content_block_stop");
 		const toolCall = result.content[0];
 		expect(toolCall?.type).toBe("toolCall");
 		if (toolCall?.type !== "toolCall") {

--- a/packages/coding-agent/src/internal-urls/api-spec-resolve.ts
+++ b/packages/coding-agent/src/internal-urls/api-spec-resolve.ts
@@ -769,6 +769,36 @@ function renderSchemaAsTable(
 	const properties = resolved.properties as Record<string, Record<string, unknown>> | undefined;
 	if (!properties) {
 		const type = (resolved.type as string) ?? "object";
+		const items = resolved.items;
+		if (type === "array" && items && typeof items === "object" && depth < SCHEMA_RENDER_MAX_DEPTH) {
+			return renderSchemaAsTable(
+				items as Record<string, unknown>,
+				spec,
+				depth + 1,
+				`${prefix}[]`,
+				schemaRecommended,
+				nextVisited,
+			);
+		}
+		const variants = Array.isArray(resolved.oneOf)
+			? (resolved.oneOf as unknown[]).filter(
+					(variant): variant is Record<string, unknown> => typeof variant === "object" && variant !== null,
+				)
+			: [];
+		if (variants.length > 0 && depth < SCHEMA_RENDER_MAX_DEPTH) {
+			return variants
+				.map((variant, index) =>
+					renderSchemaAsTable(
+						variant,
+						spec,
+						depth + 1,
+						`${prefix}.oneOf[${index}]`,
+						schemaRecommended,
+						nextVisited,
+					),
+				)
+				.join("");
+		}
 		return `Type: ${type}\n`;
 	}
 
@@ -785,7 +815,7 @@ function renderSchemaAsTable(
 	for (const [name, prop] of Object.entries(properties)) {
 		const fieldProp = resolveSchemaRef(prop, spec);
 		const fieldName = prefix ? `${prefix}.${name}` : name;
-		const type = (fieldProp.type as string) ?? "object";
+		const type = (fieldProp.type as string) ?? (Array.isArray(fieldProp.oneOf) ? "oneOf" : "object");
 		const desc = (fieldProp.description as string) ?? "";
 		const isRequired = required.includes(name) ? "yes" : "no";
 		const constraints = formatFieldConstraints(fieldProp);
@@ -824,26 +854,34 @@ function renderSchemaAsTable(
 			}
 		}
 
-		const itemSchema =
-			type === "array" && fieldProp.items && typeof fieldProp.items === "object"
-				? resolveSchemaRef(fieldProp.items as Record<string, unknown>, spec)
-				: fieldProp;
-		if ((type === "object" || type === "array") && itemSchema.properties && depth < SCHEMA_RENDER_MAX_DEPTH) {
-			const nestedOneOf = renderOneOfGroups(itemSchema, schemaRecommended);
+		const nestedSources: Array<{ source: Record<string, unknown>; prefix: string }> = [];
+		if (type === "array" && fieldProp.items && typeof fieldProp.items === "object") {
+			nestedSources.push({ source: fieldProp.items as Record<string, unknown>, prefix: `${fieldName}[]` });
+		} else if (Array.isArray(fieldProp.oneOf)) {
+			for (const [index, variant] of fieldProp.oneOf.entries()) {
+				if (typeof variant === "object" && variant !== null) {
+					nestedSources.push({
+						source: variant as Record<string, unknown>,
+						prefix: `${fieldName}.oneOf[${index}]`,
+					});
+				}
+			}
+		} else if (type === "object") {
+			nestedSources.push({ source: prop, prefix: fieldName });
+		}
+
+		for (const { source, prefix: nestedPrefix } of nestedSources) {
+			const nestedResolved = resolveSchemaRef(source, spec);
+			if (
+				depth >= SCHEMA_RENDER_MAX_DEPTH ||
+				(!nestedResolved.properties && nestedResolved.type !== "array" && !Array.isArray(nestedResolved.oneOf))
+			) {
+				continue;
+			}
+			const nestedOneOf = renderOneOfGroups(nestedResolved, schemaRecommended);
 			if (nestedOneOf) rows.push("", nestedOneOf);
-			const nestedSource =
-				type === "array" && fieldProp.items && typeof fieldProp.items === "object"
-					? (fieldProp.items as Record<string, unknown>)
-					: prop;
-			const nested = renderSchemaAsTable(
-				nestedSource,
-				spec,
-				depth + 1,
-				type === "array" ? fieldName + "[]" : fieldName,
-				schemaRecommended,
-				nextVisited,
-			);
-			const nestedLines = nested.split("\n").filter(l => l.startsWith("|") && !l.startsWith("| Field"));
+			const nested = renderSchemaAsTable(source, spec, depth + 1, nestedPrefix, schemaRecommended, nextVisited);
+			const nestedLines = nested.split("\n").filter(line => line.startsWith("|") && !line.startsWith("| Field"));
 			rows.push(...nestedLines);
 		}
 	}

--- a/packages/coding-agent/src/internal-urls/api-spec-resolve.ts
+++ b/packages/coding-agent/src/internal-urls/api-spec-resolve.ts
@@ -832,8 +832,8 @@ function renderSchemaAsTable(
 			const nestedOneOf = renderOneOfGroups(itemSchema, schemaRecommended);
 			if (nestedOneOf) rows.push("", nestedOneOf);
 			const nestedSource =
-				type === "array" && prop.items && typeof prop.items === "object"
-					? (prop.items as Record<string, unknown>)
+				type === "array" && fieldProp.items && typeof fieldProp.items === "object"
+					? (fieldProp.items as Record<string, unknown>)
 					: prop;
 			const nested = renderSchemaAsTable(
 				nestedSource,

--- a/packages/coding-agent/src/internal-urls/api-spec-resolve.ts
+++ b/packages/coding-agent/src/internal-urls/api-spec-resolve.ts
@@ -757,9 +757,14 @@ function renderSchemaAsTable(
 	depth = 0,
 	prefix = "",
 	schemaRecommended?: Readonly<Record<string, string>>,
+	visited = new Set<string>(),
 ): string {
 	if (depth > SCHEMA_RENDER_MAX_DEPTH) return "";
 
+	const schemaName = extractSchemaName(schema);
+	if (schemaName && visited.has(schemaName)) return "";
+	const nextVisited = new Set(visited);
+	if (schemaName) nextVisited.add(schemaName);
 	const resolved = resolveSchemaRef(schema, spec);
 	const properties = resolved.properties as Record<string, Record<string, unknown>> | undefined;
 	if (!properties) {
@@ -819,10 +824,21 @@ function renderSchemaAsTable(
 			}
 		}
 
-		if (type === "object" && fieldProp.properties && depth < SCHEMA_RENDER_MAX_DEPTH) {
-			const nestedOneOf = renderOneOfGroups(fieldProp, schemaRecommended);
+		const itemSchema =
+			type === "array" && fieldProp.items && typeof fieldProp.items === "object"
+				? resolveSchemaRef(fieldProp.items as Record<string, unknown>, spec)
+				: fieldProp;
+		if ((type === "object" || type === "array") && itemSchema.properties && depth < SCHEMA_RENDER_MAX_DEPTH) {
+			const nestedOneOf = renderOneOfGroups(itemSchema, schemaRecommended);
 			if (nestedOneOf) rows.push("", nestedOneOf);
-			const nested = renderSchemaAsTable(fieldProp, spec, depth + 1, fieldName, schemaRecommended);
+			const nested = renderSchemaAsTable(
+				itemSchema,
+				spec,
+				depth + 1,
+				type === "array" ? fieldName + "[]" : fieldName,
+				schemaRecommended,
+				nextVisited,
+			);
 			const nestedLines = nested.split("\n").filter(l => l.startsWith("|") && !l.startsWith("| Field"));
 			rows.push(...nestedLines);
 		}

--- a/packages/coding-agent/src/internal-urls/api-spec-resolve.ts
+++ b/packages/coding-agent/src/internal-urls/api-spec-resolve.ts
@@ -831,8 +831,12 @@ function renderSchemaAsTable(
 		if ((type === "object" || type === "array") && itemSchema.properties && depth < SCHEMA_RENDER_MAX_DEPTH) {
 			const nestedOneOf = renderOneOfGroups(itemSchema, schemaRecommended);
 			if (nestedOneOf) rows.push("", nestedOneOf);
+			const nestedSource =
+				type === "array" && prop.items && typeof prop.items === "object"
+					? (prop.items as Record<string, unknown>)
+					: prop;
 			const nested = renderSchemaAsTable(
-				itemSchema,
+				nestedSource,
 				spec,
 				depth + 1,
 				type === "array" ? fieldName + "[]" : fieldName,

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -380,6 +380,8 @@ Set a session-wide default with `set_presentation_profile`.
   The `xcsh_api` tool handles authentication, URL construction, and HTTP execution.
   Never construct cURL commands for F5 XC API calls — use `xcsh_api` instead.
 
+  **CLI portability:** Prefer broadly supported flags and output fields. Before using version-specific diagnostics, inspect the installed tool version or help. If an optional diagnostic field is unsupported (for example curl 8.7.1 does not provide ssl_cipher), retry without that field while preserving and reporting the underlying command result. Do not add command interception layers or tool-specific compatibility shims.
+
   After `xcsh_api` returns a 200 or 201 response, report the result immediately.
   Do not issue a follow-up GET to verify — the response body is the verification.
   Only issue a GET if the user explicitly asks to read current state, or if the

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -380,7 +380,7 @@ Set a session-wide default with `set_presentation_profile`.
   The `xcsh_api` tool handles authentication, URL construction, and HTTP execution.
   Never construct cURL commands for F5 XC API calls — use `xcsh_api` instead.
 
-  **CLI portability:** Prefer broadly supported flags and output fields. Before using version-specific diagnostics, inspect the installed tool version or help. If an optional diagnostic field is unsupported (for example curl 8.7.1 does not provide ssl_cipher), retry without that field while preserving and reporting the underlying command result. Do not add command interception layers or tool-specific compatibility shims.
+  **CLI portability:** Prefer broadly supported flags and output fields. Before using version-specific diagnostics, inspect the installed tool version or help. If an optional diagnostic field is unsupported (for example cURL 8.7.1 does not provide ssl_cipher), retry without that field while preserving and reporting the underlying command result. Do not add command interception layers or tool-specific compatibility shims.
 
   After `xcsh_api` returns a 200 or 201 response, report the result immediately.
   Do not issue a follow-up GET to verify — the response body is the verification.

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -799,6 +799,23 @@ export class AgentSession {
 		}
 
 		// Deobfuscate assistant message content for display emission — the LLM echoes back
+		// A terminal-envelope error means the provider never completed the response.
+		// Persist its diagnostics, but never retain text, tool arguments, or other partial content.
+		if (
+			event.type === "message_end" &&
+			event.message.role === "assistant" &&
+			event.message.stopReason === "error" &&
+			this.#isTransientEnvelopeErrorMessage(event.message.errorMessage ?? "")
+		) {
+			const discardedMessage: AssistantMessage = { ...event.message, content: [] };
+			event = { ...event, message: discardedMessage };
+			const messages = this.agent.state.messages;
+			const lastMessage = messages.at(-1);
+			if (lastMessage?.role === "assistant" && lastMessage.timestamp === discardedMessage.timestamp) {
+				this.agent.replaceMessages([...messages.slice(0, -1), discardedMessage]);
+			}
+		}
+
 		// obfuscated placeholders, but listeners (TUI, extensions, exporters) must see real
 		// values. The original event.message stays obfuscated so the persistence path below
 		// writes `#HASH#` tokens to the session file; convertToLlm re-obfuscates outbound

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5888,8 +5888,8 @@ export class AgentSession {
 	}
 
 	#isTransientEnvelopeErrorMessage(errorMessage: string): boolean {
-		// Match Anthropic stream-envelope failures that indicate a broken stream before any content starts.
-		return /anthropic stream envelope error:/i.test(errorMessage) && /before message_start/i.test(errorMessage);
+		// A terminal-envelope failure is a discarded attempt; the provider never returns its partial content as a completed message.
+		return /anthropic stream envelope error:/i.test(errorMessage);
 	}
 
 	#isTransientTransportErrorMessage(errorMessage: string): boolean {

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as path from "node:path";
-import { Agent } from "@f5-sales-demo/pi-agent-core";
+import { Agent, type AgentTool } from "@f5-sales-demo/pi-agent-core";
 import { type AssistantMessage, Effort, getBundledModel, type Model } from "@f5-sales-demo/pi-ai";
 import { AssistantMessageEventStream } from "@f5-sales-demo/pi-ai/utils/event-stream";
 import { TempDir } from "@f5-sales-demo/pi-utils";
+import { Type } from "@sinclair/typebox";
 import { ModelRegistry } from "../src/config/model-registry";
 import { Settings } from "../src/config/settings";
 import { AgentSession, type AgentSessionEvent } from "../src/session/agent-session";
@@ -485,6 +486,146 @@ describe("AgentSession retry fallback", () => {
 		});
 		expect(session.messages.filter(message => message.role === "assistant")).toHaveLength(1);
 		expect(JSON.stringify(session.messages)).not.toContain("partial assistant content that must not persist");
+	});
+
+	it("retries a discarded post-content tool envelope without executing its partial tool", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) {
+			throw new Error("Expected bundled Anthropic test model to exist");
+		}
+
+		const envelopeError =
+			"Anthropic stream envelope error: stream ended before terminal stop signal (provider=anthropic, model=claude-sonnet-4-5, api=anthropic-messages, responseId=msg_partial_tool, lastEvent=content_block_stop)";
+		const requestedModels: string[] = [];
+		let attemptCount = 0;
+		let toolExecutions = 0;
+		const toolStartEvents: Array<Extract<AgentSessionEvent, { type: "tool_execution_start" }>> = [];
+		const partialTool: AgentTool = {
+			name: "partial_lookup",
+			label: "Partial lookup",
+			description: "Must never execute from a discarded stream.",
+			parameters: Type.Object({}),
+			execute: async () => {
+				toolExecutions += 1;
+				return { content: [{ type: "text", text: "unexpected execution" }] };
+			},
+		};
+
+		const agent = new Agent({
+			getApiKey: provider => `${provider}-test-key`,
+			initialState: {
+				model,
+				systemPrompt: "Test",
+				tools: [partialTool],
+				messages: [],
+			},
+			streamFn: requestedModel => {
+				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
+				const stream = new MockAssistantStream();
+				queueMicrotask(() => {
+					attemptCount += 1;
+					if (attemptCount === 1) {
+						const message: AssistantMessage = {
+							...createAssistantMessage(requestedModel, { stopReason: "error", errorMessage: envelopeError }),
+							content: [{ type: "toolCall", id: "tool_partial", name: "partial_lookup", arguments: {} }],
+						};
+						stream.push({ type: "start", partial: message });
+						stream.push({ type: "error", reason: "error", error: message });
+						return;
+					}
+					const message = createAssistantMessage(requestedModel, {
+						text: "Recovered without running the partial tool",
+						stopReason: "stop",
+					});
+					stream.push({ type: "start", partial: createAssistantMessage(requestedModel, { stopReason: "stop" }) });
+					stream.push({ type: "done", reason: "stop", message });
+				});
+				return stream;
+			},
+		});
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 5,
+			"retry.maxRetries": 1,
+		});
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+		session = new AgentSession({ agent, sessionManager: SessionManager.inMemory(), settings, modelRegistry });
+		const { retryStartEvents, retryEndEvents } = trackRetryEvents(session);
+		session.subscribe(event => {
+			if (event.type === "tool_execution_start") {
+				toolStartEvents.push(event);
+			}
+		});
+
+		await session.prompt("Retry a discarded post-content tool envelope");
+		await session.waitForIdle();
+
+		expect(requestedModels).toEqual([`${model.provider}/${model.id}`, `${model.provider}/${model.id}`]);
+		expect(retryStartEvents).toHaveLength(1);
+		expect(retryEndEvents).toHaveLength(1);
+		expect(toolStartEvents).toHaveLength(1); // Placeholder pairing is emitted; the handler itself must not run.
+		expect(toolExecutions).toBe(0);
+		expect(getLastAssistantMessage(session).content).toContainEqual({
+			type: "text",
+			text: "Recovered without running the partial tool",
+		});
+	});
+
+	it("surfaces terminal-envelope diagnostics after retry exhaustion", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) {
+			throw new Error("Expected bundled Anthropic test model to exist");
+		}
+
+		const envelopeError =
+			"Anthropic stream envelope error: stream ended before terminal stop signal (provider=anthropic, model=claude-sonnet-4-5, api=anthropic-messages, responseId=msg_retry_exhausted, lastEvent=content_block_delta)";
+		const requestedModels: string[] = [];
+		const agent = new Agent({
+			getApiKey: provider => `${provider}-test-key`,
+			initialState: { model, systemPrompt: "Test", tools: [], messages: [] },
+			streamFn: requestedModel => {
+				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
+				const stream = new MockAssistantStream();
+				queueMicrotask(() => {
+					const message = createAssistantMessage(requestedModel, {
+						text: "discarded partial assistant text",
+						stopReason: "error",
+						errorMessage: envelopeError,
+					});
+					stream.push({ type: "start", partial: message });
+					stream.push({ type: "error", reason: "error", error: message });
+				});
+				return stream;
+			},
+		});
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 5,
+			"retry.maxRetries": 1,
+		});
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+		session = new AgentSession({ agent, sessionManager: SessionManager.inMemory(), settings, modelRegistry });
+		const { retryStartEvents, retryEndEvents } = trackRetryEvents(session);
+
+		await session.prompt("Retry then surface stream-envelope diagnostics");
+		await session.waitForIdle();
+
+		expect(requestedModels).toEqual([`${model.provider}/${model.id}`, `${model.provider}/${model.id}`]);
+		expect(retryStartEvents).toHaveLength(1);
+		expect(retryEndEvents).toContainEqual({
+			type: "auto_retry_end",
+			success: false,
+			attempt: 1,
+			finalError: envelopeError,
+		});
+		const lastAssistant = getLastAssistantMessage(session);
+		expect(lastAssistant.stopReason).toBe("error");
+		expect(lastAssistant.errorMessage).toBe(envelopeError);
+		expect(lastAssistant.errorMessage).toContain("responseId=msg_retry_exhausted");
+		expect(lastAssistant.errorMessage).toContain("lastEvent=content_block_delta");
+		expect(session.messages.filter(message => message.role === "assistant")).toHaveLength(1);
+		expect(JSON.stringify(session.messages)).not.toContain("discarded partial assistant text");
 	});
 
 	it("does not auto-retry generic Request was aborted. errors", async () => {

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -416,7 +416,20 @@ describe("AgentSession retry fallback", () => {
 				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
 				const stream = new MockAssistantStream();
 				queueMicrotask(() => {
+					if (requestedModel.provider === fallbackModel.provider && requestedModel.id === fallbackModel.id) {
+						const message = createAssistantMessage(requestedModel, {
+							text: "Recovered after discarded Anthropic stream",
+							stopReason: "stop",
+						});
+						stream.push({
+							type: "start",
+							partial: createAssistantMessage(requestedModel, { stopReason: "stop" }),
+						});
+						stream.push({ type: "done", reason: "stop", message });
+						return;
+					}
 					const message = createAssistantMessage(requestedModel, {
+						text: "partial assistant content that must not persist",
 						stopReason: "error",
 						errorMessage: envelopeError,
 					});
@@ -456,14 +469,22 @@ describe("AgentSession retry fallback", () => {
 		await session.prompt("Retry Anthropic envelope failure before terminal stop signal");
 		await session.waitForIdle();
 
-		expect(requestedModels).toHaveLength(2);
+		expect(requestedModels).toEqual([
+			`${primaryModel.provider}/${primaryModel.id}`,
+			`${fallbackModel.provider}/${fallbackModel.id}`,
+		]);
 		expect(retryStartEvents).toHaveLength(1);
 		expect(retryEndEvents).toHaveLength(1);
 		expect(fallbackAppliedEvents).toHaveLength(1);
-		expect(fallbackSucceededEvents).toHaveLength(0);
+		expect(fallbackSucceededEvents).toHaveLength(1);
 		const lastAssistant = getLastAssistantMessage(session);
-		expect(lastAssistant.stopReason).toBe("error");
-		expect(lastAssistant.errorMessage).toBe(envelopeError);
+		expect(lastAssistant.stopReason).toBe("stop");
+		expect(lastAssistant.content).toContainEqual({
+			type: "text",
+			text: "Recovered after discarded Anthropic stream",
+		});
+		expect(session.messages.filter(message => message.role === "assistant")).toHaveLength(1);
+		expect(JSON.stringify(session.messages)).not.toContain("partial assistant content that must not persist");
 	});
 
 	it("does not auto-retry generic Request was aborted. errors", async () => {

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -392,7 +392,7 @@ describe("AgentSession retry fallback", () => {
 		expect(lastAssistant.content).toContainEqual({ type: "text", text: "Recovered after Anthropic envelope retry" });
 	});
 
-	it("does not auto-retry Anthropic stream-envelope failures before terminal stop signal", async () => {
+	it("retries Anthropic stream-envelope failures before terminal stop signal", async () => {
 		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
 		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");
 		if (!primaryModel || !fallbackModel) {
@@ -453,13 +453,13 @@ describe("AgentSession retry fallback", () => {
 			}
 		});
 
-		await session.prompt("Do not retry Anthropic envelope failure before terminal stop signal");
+		await session.prompt("Retry Anthropic envelope failure before terminal stop signal");
 		await session.waitForIdle();
 
-		expect(requestedModels).toEqual([`${primaryModel.provider}/${primaryModel.id}`]);
-		expect(retryStartEvents).toHaveLength(0);
-		expect(retryEndEvents).toHaveLength(0);
-		expect(fallbackAppliedEvents).toHaveLength(0);
+		expect(requestedModels).toHaveLength(2);
+		expect(retryStartEvents).toHaveLength(1);
+		expect(retryEndEvents).toHaveLength(1);
+		expect(fallbackAppliedEvents).toHaveLength(1);
 		expect(fallbackSucceededEvents).toHaveLength(0);
 		const lastAssistant = getLastAssistantMessage(session);
 		expect(lastAssistant.stopReason).toBe("error");

--- a/packages/coding-agent/test/internal-urls/api-spec-array-render.test.ts
+++ b/packages/coding-agent/test/internal-urls/api-spec-array-render.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "bun:test";
+import { createApiSpecResolver } from "../../src/internal-urls/api-spec-resolve";
+import type { ApiSpecIndex, OpenAPISpec } from "../../src/internal-urls/api-spec-types";
+import type { InternalUrl } from "../../src/internal-urls/types";
+
+function url(value: string): InternalUrl {
+	const parsed = new URL(value) as InternalUrl;
+	parsed.rawHost = "api-spec";
+	parsed.rawPathname = "/test";
+	return parsed;
+}
+
+const index = {
+	version: "1.0.0",
+	timestamp: "2026-08-27T00:00:00Z",
+	criticalResources: [],
+	domains: [
+		{
+			domain: "test",
+			title: "Test",
+			description: "Test schemas",
+			descriptionShort: "Test schemas",
+			category: "Test",
+			pathCount: 1,
+			schemaCount: 1,
+			complexity: "simple",
+			resources: [{ name: "widget", description: "Widget", apiPaths: ["/widgets"] }],
+		},
+	],
+} as ApiSpecIndex;
+
+const spec = {
+	info: { title: "Test", version: "1.0.0" },
+	paths: {
+		"/widgets": {
+			post: {
+				summary: "Create widget",
+				operationId: "widget.API.Create",
+				requestBody: { content: { "application/json": { schema: { $ref: "#/components/schemas/Root" } } } },
+				responses: {},
+			},
+		},
+	},
+	components: {
+		schemas: {
+			Root: {
+				type: "object",
+				properties: {
+					direct: { type: "array", items: { type: "object", properties: { name: { type: "string" } } } },
+					referenced: { $ref: "#/components/schemas/ReferencedArray" },
+					nested: { type: "array", items: { type: "array", items: { $ref: "#/components/schemas/Item" } } },
+					choice: { oneOf: [{ $ref: "#/components/schemas/ChoiceA" }, { $ref: "#/components/schemas/ChoiceB" }] },
+					status: {
+						type: "string",
+						description: "Lifecycle state",
+						"x-ves-example": "ready",
+						"x-f5xc-constraints": { enum: ["ready", "paused"] },
+					},
+					cycle: { $ref: "#/components/schemas/Cycle" },
+					depth: { $ref: "#/components/schemas/DepthOne" },
+				},
+			},
+			ReferencedArray: { type: "array", items: { $ref: "#/components/schemas/Item" } },
+			Item: { type: "object", properties: { itemName: { type: "string" } } },
+			ChoiceA: { type: "object", properties: { alpha: { type: "string" } } },
+			ChoiceB: { type: "object", properties: { beta: { type: "string" } } },
+			Cycle: {
+				type: "object",
+				properties: { label: { type: "string" }, self: { $ref: "#/components/schemas/Cycle" } },
+			},
+			DepthOne: { type: "object", properties: { two: { $ref: "#/components/schemas/DepthTwo" } } },
+			DepthTwo: { type: "object", properties: { three: { $ref: "#/components/schemas/DepthThree" } } },
+			DepthThree: { type: "object", properties: { four: { $ref: "#/components/schemas/DepthFour" } } },
+			DepthFour: { type: "object", properties: { five: { type: "string" } } },
+		},
+	},
+} as OpenAPISpec;
+
+describe("API specification schema rendering", () => {
+	it("renders arrays from raw references with bounded oneOf and cycle traversal", async () => {
+		const result = await createApiSpecResolver(index, { test: spec }).resolve(
+			url("xcsh://api-spec/test?resource=widget"),
+		);
+		expect(result.content).toContain("direct[].name");
+		expect(result.content).toContain("referenced[].itemName");
+		expect(result.content).toContain("nested[][].itemName");
+		expect(result.content).toContain("choice.oneOf[0].alpha");
+		expect(result.content).toContain("choice.oneOf[1].beta");
+		expect(result.content).toContain("enum: ready, paused");
+		expect(result.content).toContain("Lifecycle state");
+		expect(result.content).toContain("ready");
+		expect(result.content).toContain("cycle.label");
+		expect(result.content).toContain("depth.two.three.four");
+		expect(result.content).not.toContain("depth.two.three.four.five");
+		expect(result.content.length).toBeLessThan(20_000);
+	});
+});

--- a/packages/coding-agent/test/placeholder-hygiene.test.ts
+++ b/packages/coding-agent/test/placeholder-hygiene.test.ts
@@ -110,13 +110,13 @@ describe("placeholder hygiene", () => {
 		// Both emitted artifacts must go through the sanitiser, or the next upstream sync undoes #2650.
 		// Matched loosely on purpose: sanitisers compose (#2677 wraps this one), and pinning the exact
 		// call text made this assertion fail for a correct change rather than an incorrect one.
-		expect(text).toMatch(/Bun\.write\(outputPath,[^;]*sanitizeAcmePlaceholders\(output\)/);
+		expect(text).toMatch(/Bun\.write\(\s*outputPath,\s*[^;]*sanitizeAcmePlaceholders\(output\)/);
 		expect(text).toMatch(/Bun\.write\([^;]*catalogOutputPath,[^;]*sanitizeAcmePlaceholders\(catalogOutput\)/);
 		// Contact addresses at real domains are sanitised at the same write sites (#2677).
-		expect(text).toMatch(/Bun\.write\(outputPath,[^;]*sanitizeEmails\(/);
+		expect(text).toMatch(/Bun\.write\(\s*outputPath,\s*[^;]*sanitizeEmails\(/);
 		expect(text).toMatch(/Bun\.write\([^;]*catalogOutputPath,[^;]*sanitizeEmails\(/);
 		// Globally routable examples are rewritten into RFC 5737 space at both write sites (#2674).
-		expect(text).toMatch(/Bun\.write\(outputPath,[^;]*sanitizePublicIpv4Examples\(/);
+		expect(text).toMatch(/Bun\.write\(\s*outputPath,\s*[^;]*sanitizePublicIpv4Examples\(/);
 		expect(text).toMatch(/Bun\.write\([^;]*catalogOutputPath,[^;]*sanitizePublicIpv4Examples\(/);
 
 		const consoleGenerator = fs.readFileSync(

--- a/packages/coding-agent/test/system-prompt-api-spec.test.ts
+++ b/packages/coding-agent/test/system-prompt-api-spec.test.ts
@@ -68,11 +68,11 @@ describe("system prompt API spec integration", () => {
 		expect(rendered).toContain("`xcsh://api-spec/` **MUST NOT** be read proactively");
 	});
 
-	it("preserves portable CLI diagnostics guidance for curl 8.7.1", async () => {
+	it("preserves portable CLI diagnostics guidance for cURL 8.7.1", async () => {
 		const rendered = await buildSystemPrompt({ tools: new Map() });
 		expect(rendered).toContain("CLI portability");
 		expect(rendered).toContain("inspect the installed tool version or help");
-		expect(rendered).toContain("curl 8.7.1 does not provide ssl_cipher");
+		expect(rendered).toContain("cURL 8.7.1 does not provide ssl_cipher");
 		expect(rendered).toContain("retry without that field");
 	});
 });

--- a/packages/coding-agent/test/system-prompt-api-spec.test.ts
+++ b/packages/coding-agent/test/system-prompt-api-spec.test.ts
@@ -67,4 +67,12 @@ describe("system prompt API spec integration", () => {
 		const rendered = await buildSystemPrompt({ tools: new Map() });
 		expect(rendered).toContain("`xcsh://api-spec/` **MUST NOT** be read proactively");
 	});
+
+	it("preserves portable CLI diagnostics guidance for curl 8.7.1", async () => {
+		const rendered = await buildSystemPrompt({ tools: new Map() });
+		expect(rendered).toContain("CLI portability");
+		expect(rendered).toContain("inspect the installed tool version or help");
+		expect(rendered).toContain("curl 8.7.1 does not provide ssl_cipher");
+		expect(rendered).toContain("retry without that field");
+	});
 });


### PR DESCRIPTION
## Summary

- classifies terminal Anthropic envelope failures as session-retryable and reports provider, model, route, response ID, and last-event diagnostics
- discards incomplete assistant content from terminal-envelope failures, including after retry exhaustion; partial tool handlers never execute
- adds portable-first CLI guidance for optional diagnostics, including cURL 8.7.1 without `ssl_cipher`
- recursively renders direct, referenced, nested, and `oneOf` array schemas with depth and reference-cycle protection
- keeps the inherited API-index hygiene assertion tolerant of composed sanitizer calls from current `main`

## Validation

- focused AI/session/API-renderer/prompt suites (all passing)
- `bun run check` (passing; two pre-existing warnings)
- `bun run test` (passing)
- `bun run lint` (passing; two pre-existing warnings)
- `bun run pii:gate` (clean, HEAD scope)

AGY is intentionally waived for this effort while its separate flaky-review refactor is in progress.

Closes #3403
Closes #3395