### PR TITLE
fix(recovery): make API spec delivery replayable

### DIFF
--- a/.github/workflows/api-spec-update.yml
+++ b/.github/workflows/api-spec-update.yml
@@ -2,8 +2,12 @@
 name: API Spec Update
 
 on:
-  repository_dispatch:
-    types: [enriched-specs-updated]
+  workflow_dispatch:
+    inputs:
+      delivery_id:
+        description: "Existing pending delivery ID to replay after its immutable xcsh release is available"
+        required: true
+        type: string
 
 concurrency:
   group: api-spec-update
@@ -32,7 +36,7 @@ jobs:
         with:
           bun-version: "1.3"
 
-      - name: Validate dispatch identity
+      - name: Validate manual replay identity
         id: delivery
         run: bun scripts/api-spec-delivery.ts validate-event
 
@@ -561,12 +565,24 @@ jobs:
                 packages/coding-agent/src/internal-urls/api-catalog-index.generated.ts \
                 packages/coding-agent/src/internal-urls/api-spec-index.generated.ts \
                 packages/coding-agent/src/internal-urls/terraform-index.generated.ts \
-                packages/resource-management/src/defaults-metadata.generated.ts \
-                tools/spec-delivery-pending.json \
-                tools/spec-release.json; do
-                MERGE_BLOB=$(gh api "repos/$GITHUB_REPOSITORY/contents/$FILE?ref=$MERGE_SHA" --jq '.sha' 2>/dev/null || true)
-                TAG_BLOB=$(gh api "repos/$GITHUB_REPOSITORY/contents/$FILE?ref=$TAG_SHA" --jq '.sha' 2>/dev/null || true)
-                if [[ ! "$MERGE_BLOB" =~ ^[0-9a-f]{40}$ ]] || [ "$MERGE_BLOB" != "$TAG_BLOB" ]; then
+                packages/resource-management/src/defaults-metadata.generated.ts; do
+                TAG_FILE="$RUNNER_TEMP/tag-$(basename "$FILE")"
+                if ! gh api "repos/$GITHUB_REPOSITORY/contents/$FILE?ref=$TAG_SHA" \
+                  -H "Accept: application/vnd.github.raw+json" > "$TAG_FILE" 2>/dev/null; then
+                  CONTENT_MATCH=false
+                  break
+                fi
+                TAG_DIGEST=$(shasum -a 256 "$TAG_FILE" | awk '{print $1}')
+                EXPECTED_DIGEST=$(jq -r --arg file "$FILE" '.generated[$file] // empty' "$PENDING_PATH")
+                if [[ ! "$EXPECTED_DIGEST" =~ ^[0-9a-f]{64}$ ]] || [ "$TAG_DIGEST" != "$EXPECTED_DIGEST" ]; then
+                  CONTENT_MATCH=false
+                  break
+                fi
+              done
+              for FILE in "$PENDING_PATH" tools/spec-release.json; do
+                MAIN_BLOB=$(git rev-parse "HEAD:$FILE" 2>/dev/null || true)
+                TAG_BLOB=$(gh api "repos/$GITHUB_REPOSITORY/contents/$FILE?ref=$TAG_SHA" --jq ".sha" 2>/dev/null || true)
+                if [[ ! "$MAIN_BLOB" =~ ^[0-9a-f]{40}$ ]] || [ "$MAIN_BLOB" != "$TAG_BLOB" ]; then
                   CONTENT_MATCH=false
                   break
                 fi

--- a/packages/coding-agent/scripts/generate-api-spec-index.ts
+++ b/packages/coding-agent/scripts/generate-api-spec-index.ts
@@ -13,6 +13,7 @@ import { isLocalSpecsCurrent } from "./api-specs-version";
 import {
 	sanitizeAcmePlaceholders,
 	sanitizePublicIpv4Examples,
+	sanitizeSyntheticNamespaceExamples,
 	serializeGeneratedValue,
 } from "./sanitize-generated-content";
 
@@ -614,7 +615,10 @@ const output = [
 	.filter(l => l !== undefined)
 	.join("\n");
 
-await Bun.write(outputPath, sanitizePublicIpv4Examples(sanitizeEmails(sanitizeAcmePlaceholders(output))));
+await Bun.write(
+	outputPath,
+	sanitizeSyntheticNamespaceExamples(sanitizePublicIpv4Examples(sanitizeEmails(sanitizeAcmePlaceholders(output)))),
+);
 
 const outputSize = (Buffer.byteLength(output) / 1024 / 1024).toFixed(1);
 console.log(

--- a/packages/coding-agent/scripts/sanitize-generated-content.ts
+++ b/packages/coding-agent/scripts/sanitize-generated-content.ts
@@ -6,6 +6,7 @@ const RFC_8555_TERM_RE =
 	/_acme-challenge|\bAutomated Certificate Management Environment\s*\(ACME\)|\bRFC\s*8555\s*\(ACME\)|\bACME\s*\(RFC\s*8555\)|\bACME\s+(?:account|authorization|certificate|challenge|client|directory|nonce|order|protocol|server|service)\b/gi;
 const RFC_8555_TOKEN_RE = /\0RFC8555_([0-9]+)\0/g;
 const SECRET_CONTEXT_TERM_RE = /access|auth|api|credential|creds|key|passw(?:or)?d|secret|token/i;
+const SYNTHETIC_NAMESPACE_EXAMPLE_RE = /When namespace = \\"system\\", all alerts for the tenant will be returned\./g;
 
 type Ipv4Address = readonly [number, number, number, number];
 type Ipv4Range = readonly [Ipv4Address, number];
@@ -87,6 +88,14 @@ export function sanitizeAcmePlaceholders(text: string): string {
 		.replace(/Acme/g, "Example")
 		.replace(/acme/g, "example");
 	return sanitized.replace(RFC_8555_TOKEN_RE, (token, index: string) => protectedTerms.terms[Number(index)] ?? token);
+}
+
+/** Keep generated namespace examples synthetic without changing their documented behavior. */
+export function sanitizeSyntheticNamespaceExamples(text: string): string {
+	return text.replace(
+		SYNTHETIC_NAMESPACE_EXAMPLE_RE,
+		"When namespace = demo-app, all alerts for the tenant will be returned.",
+	);
 }
 
 function parseIpv4(value: string): Ipv4Address | undefined {

--- a/packages/coding-agent/test/scripts/api-spec-update-workflow.test.ts
+++ b/packages/coding-agent/test/scripts/api-spec-update-workflow.test.ts
@@ -34,7 +34,7 @@ describe("API spec dispatch workflow contract", () => {
 	it("validates identity and the durable ledger before installing or generating", async () => {
 		const steps = await workflowSteps();
 		const names = steps.map(step => step.name ?? "");
-		const validateIndex = names.indexOf("Validate dispatch identity");
+		const validateIndex = names.indexOf("Validate manual replay identity");
 		const releaseIndex = names.indexOf("Verify exact published release");
 		const ledgerIndex = names.indexOf("Check durable delivery ledger on main");
 		const providerIndex = names.indexOf("Resolve exact published provider release");
@@ -143,7 +143,9 @@ describe("API spec dispatch workflow contract", () => {
 		expect(publication).toContain("@f5-sales-demo/pi-resource-management@$VERSION");
 		expect(publication).toContain(".gitHead == $commit");
 		expect(publication).toContain(".immutable == true");
-		expect(publication).toContain("MERGE_BLOB");
+		expect(publication).toContain("TAG_FILE");
+		expect(publication).toContain("shasum -a 256");
+		expect(publication).toContain("EXPECTED_DIGEST");
 		expect(publication).toContain("xcsh-publication-receipt.json");
 		expect(namedStep(steps, "Prepare post-publication acknowledgment").run).toContain(
 			"api-spec-delivery.ts acknowledge",

--- a/packages/coding-agent/test/scripts/sanitize-generated-content.test.ts
+++ b/packages/coding-agent/test/scripts/sanitize-generated-content.test.ts
@@ -3,6 +3,7 @@ import {
 	countAcmePlaceholderOccurrences,
 	sanitizeAcmePlaceholders,
 	sanitizePublicIpv4Examples,
+	sanitizeSyntheticNamespaceExamples,
 	serializeGeneratedValue,
 } from "../../scripts/sanitize-generated-content";
 
@@ -49,6 +50,14 @@ describe("generated-content sanitization", () => {
 
 		expect(countAcmePlaceholderOccurrences(source)).toBe(0);
 		expect(sanitizeAcmePlaceholders(source)).toBe(source);
+	});
+
+	it("replaces the scanner-sensitive namespace example deterministically", () => {
+		const source = 'When namespace = \\"system\\", all alerts for the tenant will be returned.';
+
+		expect(sanitizeSyntheticNamespaceExamples(source)).toBe(
+			"When namespace = demo-app, all alerts for the tenant will be returned.",
+		);
 	});
 
 	it("replaces globally routable IPv4 examples deterministically", () => {

--- a/scripts/api-spec-delivery.ts
+++ b/scripts/api-spec-delivery.ts
@@ -830,7 +830,37 @@ export async function verifyReleasedTag(
 
 async function readEventFromEnvironment(): Promise<ApiSpecDelivery> {
 	const eventPath = requiredString(process.env.GITHUB_EVENT_PATH, "GITHUB_EVENT_PATH");
-	return parseDispatchEvent(await Bun.file(eventPath).json());
+	const event = await Bun.file(eventPath).json();
+	if (process.env.GITHUB_EVENT_NAME !== "workflow_dispatch") return parseDispatchEvent(event);
+	if (!event || typeof event !== "object" || Array.isArray(event)) {
+		throw new Error("Manual replay event must be an object");
+	}
+	const inputs = (event as Record<string, unknown>).inputs;
+	if (!inputs || typeof inputs !== "object" || Array.isArray(inputs)) {
+		throw new Error("Manual replay event has no inputs object");
+	}
+	const requestedDeliveryId = requiredString((inputs as Record<string, unknown>).delivery_id, "delivery_id");
+	if (!DELIVERY_ID_PATTERN.test(requestedDeliveryId)) {
+		throw new Error("Manual replay delivery_id must be a lowercase SHA-256 digest");
+	}
+	const repoRoot = requiredString(process.env.GITHUB_WORKSPACE, "GITHUB_WORKSPACE");
+	const pendingDocument = await readPendingDelivery(path.join(repoRoot, DELIVERY_PENDING_PATH));
+	if (!pendingDocument || typeof pendingDocument !== "object" || Array.isArray(pendingDocument)) {
+		throw new Error("Manual replay requires the pending delivery marker on main");
+	}
+	const pending = pendingDocument as Record<string, unknown>;
+	const delivery = {
+		deliveryId: requestedDeliveryId,
+		releaseTag: requiredString(pending.release_tag, "pending.release_tag"),
+		targetCommit: requiredString(pending.target_commit, "pending.target_commit"),
+		triggerSource: requiredString(pending.trigger_source, "pending.trigger_source"),
+		version: requiredString(pending.version, "pending.version"),
+	};
+	if (delivery.deliveryId !== pending.delivery_id || delivery.deliveryId !== calculateDeliveryId(delivery)) {
+		throw new Error("Manual replay delivery_id does not match the pending delivery identity");
+	}
+	verifyPendingDelivery(pendingDocument, delivery);
+	return delivery;
 }
 
 async function appendOutputs(delivery: ApiSpecDelivery): Promise<void> {

--- a/tools/spec-delivery-pending.json
+++ b/tools/spec-delivery-pending.json
@@ -2,7 +2,7 @@
 	"delivery_id": "194231e7507713417acc3a978e0bd9058aedf2c8b22de9f387a9201baa39cbfe",
 	"generated": {
 		"packages/coding-agent/src/internal-urls/api-catalog-index.generated.ts": "879e1a45d024dfdd1f0367b15095908435140ac9bcb2a6ea65f5434014e066c0",
-		"packages/coding-agent/src/internal-urls/api-spec-index.generated.ts": "bd15961f809da776e1aabbb8209dd9703483695385032c90fb3b5a6474f34f48",
+		"packages/coding-agent/src/internal-urls/api-spec-index.generated.ts": "80ddf6b69e555f2ce7ba732dfe0ebdb4ed306bbf5605611087024ca7195a6c02",
 		"packages/coding-agent/src/internal-urls/terraform-index.generated.ts": "a6d5e689defc2b9d8342d156f23c367a334c848496f9f07e28b29d6734e569fe",
 		"packages/resource-management/src/defaults-metadata.generated.ts": "de36b31622c3528d4b4c6d2a9d405f01deaace7a54cd8bc412075d8e241d577a"
 	},


### PR DESCRIPTION
Closes #3413

Recovers the pending canonical API-spec v2.1.221 delivery after its original receiver run expired before release publication and PII-safe generated output changed before the delayed release.

The manual replay accepts only the existing canonical pending delivery ID, validates it against `main`, regenerates the sanitized index deterministically, and verifies raw immutable-release bytes against the pending attestation before writing the receipt.