### PR TITLE
fix(test): allow formatted API spec sanitizer calls

### DIFF
--- a/packages/coding-agent/test/placeholder-hygiene.test.ts
+++ b/packages/coding-agent/test/placeholder-hygiene.test.ts
@@ -110,20 +110,20 @@ describe("placeholder hygiene", () => {
 		// Both emitted artifacts must go through the sanitiser, or the next upstream sync undoes #2650.
 		// Matched loosely on purpose: sanitisers compose (#2677 wraps this one), and pinning the exact
 		// call text made this assertion fail for a correct change rather than an incorrect one.
-		expect(text).toMatch(/Bun\.write\(outputPath,[^;]*sanitizeAcmePlaceholders\(output\)/);
+		expect(text).toMatch(/Bun\.write\(\s*outputPath,[^;]*sanitizeAcmePlaceholders\(output\)/);
 		expect(text).toMatch(/Bun\.write\([^;]*catalogOutputPath,[^;]*sanitizeAcmePlaceholders\(catalogOutput\)/);
 		// Contact addresses at real domains are sanitised at the same write sites (#2677).
-		expect(text).toMatch(/Bun\.write\(outputPath,[^;]*sanitizeEmails\(/);
+		expect(text).toMatch(/Bun\.write\(\s*outputPath,[^;]*sanitizeEmails\(/);
 		expect(text).toMatch(/Bun\.write\([^;]*catalogOutputPath,[^;]*sanitizeEmails\(/);
 		// Globally routable examples are rewritten into RFC 5737 space at both write sites (#2674).
-		expect(text).toMatch(/Bun\.write\(outputPath,[^;]*sanitizePublicIpv4Examples\(/);
+		expect(text).toMatch(/Bun\.write\(\s*outputPath,[^;]*sanitizePublicIpv4Examples\(/);
 		expect(text).toMatch(/Bun\.write\([^;]*catalogOutputPath,[^;]*sanitizePublicIpv4Examples\(/);
 
 		const consoleGenerator = fs.readFileSync(
 			path.join(REPO_ROOT, "packages/coding-agent/scripts/generate-console-catalog.ts"),
 			"utf8",
 		);
-		expect(consoleGenerator).toMatch(/Bun\.write\(outputPath,[^;]*sanitizePublicIpv4Examples\(/);
+		expect(consoleGenerator).toMatch(/Bun\.write\(\s*outputPath,[^;]*sanitizePublicIpv4Examples\(/);
 	});
 
 	it("generated API indexes contain only reserved-domain contact addresses", () => {


### PR DESCRIPTION
Closes #3415

Follow-up to #3413: preserves the sanitizer invariant while allowing Biome to format the `Bun.write` call across lines. This unblocks the canonical API-spec delivery release chain.