### PR TITLE
fix(recovery): resume acknowledged manual replays

### DIFF
--- a/.github/workflows/api-spec-update.yml
+++ b/.github/workflows/api-spec-update.yml
@@ -773,6 +773,11 @@ jobs:
       - name: Verify acknowledgment reached main
         if: steps.main_delivery.outputs.applied != 'true'
         env:
+          DELIVERY_ID: ${{ steps.delivery.outputs.delivery_id }}
+          DELIVERY_RELEASE_TAG: ${{ steps.delivery.outputs.release_tag }}
+          DELIVERY_TARGET_COMMIT: ${{ steps.delivery.outputs.target_commit }}
+          DELIVERY_TRIGGER_SOURCE: ${{ steps.delivery.outputs.trigger_source }}
+          DELIVERY_VERSION: ${{ steps.delivery.outputs.version }}
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           LEDGER_PATH: ${{ steps.delivery.outputs.ledger_path }}
           PUBLICATION_LEDGER_PATH: ${{ steps.delivery.outputs.publication_ledger_path }}

--- a/scripts/api-spec-delivery.ts
+++ b/scripts/api-spec-delivery.ts
@@ -863,6 +863,20 @@ async function readEventFromEnvironment(): Promise<ApiSpecDelivery> {
 	return delivery;
 }
 
+function readVerificationDeliveryFromEnvironment(): ApiSpecDelivery {
+	const delivery = {
+		deliveryId: requiredString(process.env.DELIVERY_ID, "DELIVERY_ID"),
+		releaseTag: requiredString(process.env.DELIVERY_RELEASE_TAG, "DELIVERY_RELEASE_TAG"),
+		targetCommit: requiredString(process.env.DELIVERY_TARGET_COMMIT, "DELIVERY_TARGET_COMMIT"),
+		triggerSource: requiredString(process.env.DELIVERY_TRIGGER_SOURCE, "DELIVERY_TRIGGER_SOURCE"),
+		version: requiredString(process.env.DELIVERY_VERSION, "DELIVERY_VERSION"),
+	};
+	if (!DELIVERY_ID_PATTERN.test(delivery.deliveryId) || delivery.deliveryId !== calculateDeliveryId(delivery)) {
+		throw new Error("Verification delivery identity does not match its canonical fields");
+	}
+	return delivery;
+}
+
 async function appendOutputs(delivery: ApiSpecDelivery): Promise<void> {
 	const outputPath = requiredString(process.env.GITHUB_OUTPUT, "GITHUB_OUTPUT");
 	const values = {
@@ -873,6 +887,7 @@ async function appendOutputs(delivery: ApiSpecDelivery): Promise<void> {
 		pending_path: DELIVERY_PENDING_PATH,
 		publication_ledger_path: DELIVERY_PUBLICATION_LEDGER_PATH,
 		provider_delivery_id: calculateDeliveryIdForTarget(delivery, PROVIDER_REPOSITORY),
+		trigger_source: delivery.triggerSource,
 		release_tag: delivery.releaseTag,
 		target_commit: delivery.targetCommit,
 		version: delivery.version,
@@ -887,7 +902,7 @@ async function appendOutputs(delivery: ApiSpecDelivery): Promise<void> {
 
 async function main(): Promise<void> {
 	const command = process.argv[2];
-	const delivery = await readEventFromEnvironment();
+	const delivery = command === "verify-ledger" ? readVerificationDeliveryFromEnvironment() : await readEventFromEnvironment();
 	if (command === "validate-event") {
 		await appendOutputs(delivery);
 		return;

--- a/scripts/api-spec-delivery.ts
+++ b/scripts/api-spec-delivery.ts
@@ -846,7 +846,16 @@ async function readEventFromEnvironment(): Promise<ApiSpecDelivery> {
 	const repoRoot = requiredString(process.env.GITHUB_WORKSPACE, "GITHUB_WORKSPACE");
 	const pendingDocument = await readPendingDelivery(path.join(repoRoot, DELIVERY_PENDING_PATH));
 	if (!pendingDocument || typeof pendingDocument !== "object" || Array.isArray(pendingDocument)) {
-		throw new Error("Manual replay requires the pending delivery marker on main");
+		const ledger = await readDeliveryLedger(path.join(repoRoot, DELIVERY_LEDGER_PATH));
+		const entry = ledger?.deliveries[requestedDeliveryId];
+		if (!entry) throw new Error("Manual replay requires the pending delivery marker on main");
+		return {
+			deliveryId: requestedDeliveryId,
+			releaseTag: entry.release_tag,
+			targetCommit: entry.target_commit,
+			triggerSource: "acknowledged-delivery",
+			version: entry.version,
+		};
 	}
 	const pending = pendingDocument as Record<string, unknown>;
 	const delivery = {


### PR DESCRIPTION
Allows manual replay to take its idempotent durable-ledger path after acknowledgment removed the pending marker, while preserving pending-marker enforcement for unknown IDs.

Closes #3421