### PR TITLE
fix(delivery): restore enriched-specs dispatch

### DIFF
--- a/.github/workflows/api-spec-update.yml
+++ b/.github/workflows/api-spec-update.yml
@@ -2,6 +2,8 @@
 name: API Spec Update
 
 on:
+  repository_dispatch:
+    types: [enriched-specs-updated]
   workflow_dispatch:
     inputs:
       delivery_id:
@@ -36,7 +38,7 @@ jobs:
         with:
           bun-version: "1.3"
 
-      - name: Validate manual replay identity
+      - name: Validate delivery identity
         id: delivery
         run: bun scripts/api-spec-delivery.ts validate-event
 

--- a/packages/coding-agent/test/scripts/api-spec-update-workflow.test.ts
+++ b/packages/coding-agent/test/scripts/api-spec-update-workflow.test.ts
@@ -12,6 +12,10 @@ interface WorkflowStep {
 }
 
 interface WorkflowDocument {
+	on: {
+		repository_dispatch?: { types?: string[] };
+		workflow_dispatch?: { inputs?: Record<string, { required?: boolean; type?: string }> };
+	};
 	jobs: Record<string, { steps: WorkflowStep[] }>;
 }
 
@@ -31,10 +35,19 @@ function namedStep(steps: WorkflowStep[], name: string): WorkflowStep {
 }
 
 describe("API spec dispatch workflow contract", () => {
+	it("accepts canonical upstream delivery and exact pending replay triggers", async () => {
+		const document = parseYaml(await Bun.file(workflowPath).text()) as WorkflowDocument;
+		expect(document.on.repository_dispatch?.types).toEqual(["enriched-specs-updated"]);
+		expect(document.on.workflow_dispatch?.inputs?.delivery_id).toMatchObject({
+			required: true,
+			type: "string",
+		});
+	});
+
 	it("validates identity and the durable ledger before installing or generating", async () => {
 		const steps = await workflowSteps();
 		const names = steps.map(step => step.name ?? "");
-		const validateIndex = names.indexOf("Validate manual replay identity");
+		const validateIndex = names.indexOf("Validate delivery identity");
 		const releaseIndex = names.indexOf("Verify exact published release");
 		const ledgerIndex = names.indexOf("Check durable delivery ledger on main");
 		const providerIndex = names.indexOf("Resolve exact published provider release");


### PR DESCRIPTION
Closes #3425

## Summary

Restore the canonical `enriched-specs-updated` repository-dispatch receiver that recovery PR #3414 accidentally replaced, while retaining its exact pending-delivery manual replay input.

Both triggers execute the same fail-closed delivery identity parser and immutable provider/publication evidence workflow. This adds no alternate source, mutable-latest resolution, compatibility fallback, or legacy path.

## Verification

- TDD red: workflow contract failed with repository-dispatch types undefined
- focused workflow/evidence suite: 14 pass, 0 fail
- `bun run check`: pass (TypeScript and all workspace checks; two pre-existing warning-only fixture literals)
- full `bun run test`: pass
  - xcsh: 6,722 pass, 559 intentional skips, 0 fail
  - native: 40 pass, 0 fail
  - TUI: 486 pass, 0 fail
  - Office pane: 427 pass, 4 skips, 0 fail
  - all remaining workspaces: pass
- changed-file pre-commit: YAML, actionlint, Biome, workflow security, Checkov, gitleaks, spelling, and hygiene pass
- `git diff --check`: pass
- added compatibility mechanisms: 0
