### PR TITLE
fix(delivery): require complete API release assets

### DIFF
--- a/.github/workflows/api-spec-update.yml
+++ b/.github/workflows/api-spec-update.yml
@@ -269,8 +269,12 @@ jobs:
                   (keys | sort) == ["assets", "release_tag", "target_commit", "version"] and
                   .release_tag == $tag and .target_commit == $commit and .version == $version and
                   (.assets | keys | sort) == [
-                    "api-catalog.json", ("f5xc-api-specs-" + $tag + ".zip"),
-                    "index.json", "minimal-export-defaults.json", "openapi.json"
+                    "api-catalog.json", "concurrency_contracts.json",
+                    ("f5xc-api-specs-" + $tag + ".zip"), "index.json",
+                    "minimal-export-defaults.json", "openapi.json",
+                    "smsv2-contract-manifest.json", "smsv2-contract.json",
+                    "smsv2-evidence-receipt.json", "smsv2_parity_manifest.json",
+                    "upstream-contract-removals.json"
                   ] and ([.assets[] | test("^sha256:[0-9a-f]{64}$")] | all)
                 ' "$RUNNER_TEMP/provider-spec-release.json" >/dev/null || {
                   echo "::error::Provider release carries a malformed or mismatched spec pin"

--- a/packages/coding-agent/test/scripts/api-spec-delivery.test.ts
+++ b/packages/coding-agent/test/scripts/api-spec-delivery.test.ts
@@ -54,10 +54,16 @@ function specReleasePin(): Record<string, unknown> {
 	return {
 		assets: {
 			"api-catalog.json": "1".repeat(64),
+			"concurrency_contracts.json": "6".repeat(64),
 			[`f5xc-api-specs-${RELEASE_TAG}.zip`]: "2".repeat(64),
 			"index.json": "3".repeat(64),
 			"minimal-export-defaults.json": "4".repeat(64),
 			"openapi.json": "5".repeat(64),
+			"smsv2-contract-manifest.json": "7".repeat(64),
+			"smsv2-contract.json": "8".repeat(64),
+			"smsv2-evidence-receipt.json": "9".repeat(64),
+			"smsv2_parity_manifest.json": "a".repeat(64),
+			"upstream-contract-removals.json": "b".repeat(64),
 		},
 		release_tag: RELEASE_TAG,
 		target_commit: TARGET_COMMIT,
@@ -362,6 +368,31 @@ describe("published release identity", () => {
 			`https://api.github.com/repos/${TRIGGER_SOURCE}/releases/tags/${RELEASE_TAG}`,
 			`https://api.github.com/repos/${TRIGGER_SOURCE}/git/ref/tags/${RELEASE_TAG}`,
 		]);
+	});
+
+	it("rejects missing or extra assets outside the exact 11-asset release contract", async () => {
+		const missing = publishedRelease();
+		(missing.assets as Array<Record<string, string>>).pop();
+		await expect(
+			verifyReleasedTag(validDelivery(), undefined, async input =>
+				Response.json(
+					String(input).includes("/releases/tags/") ? missing : { object: { sha: TARGET_COMMIT, type: "commit" } },
+				),
+			),
+		).rejects.toThrow("wrong asset set");
+
+		const extra = publishedRelease();
+		(extra.assets as Array<Record<string, string>>).push({
+			digest: `sha256:${"c".repeat(64)}`,
+			name: "unexpected.json",
+		});
+		await expect(
+			verifyReleasedTag(validDelivery(), undefined, async input =>
+				Response.json(
+					String(input).includes("/releases/tags/") ? extra : { object: { sha: TARGET_COMMIT, type: "commit" } },
+				),
+			),
+		).rejects.toThrow("wrong asset set");
 	});
 
 	it("rejects a release tag that resolves to another commit", async () => {

--- a/packages/coding-agent/test/scripts/api-spec-update-workflow.test.ts
+++ b/packages/coding-agent/test/scripts/api-spec-update-workflow.test.ts
@@ -106,6 +106,16 @@ describe("API spec dispatch workflow contract", () => {
 		expect(provider).toContain("Provider release consumed different spec bytes from this receiver");
 		expect(provider).toContain("Provider release receipt differs from durable publication evidence");
 		expect(provider).toContain("Provider release bytes differ from publication evidence");
+		for (const asset of [
+			"concurrency_contracts.json",
+			"smsv2-contract-manifest.json",
+			"smsv2-contract.json",
+			"smsv2-evidence-receipt.json",
+			"smsv2_parity_manifest.json",
+			"upstream-contract-removals.json",
+		]) {
+			expect(provider).toContain(asset);
+		}
 		expect(provider).not.toContain("gh release list");
 		expect(namedStep(steps, "Verify exact regenerated delivery bytes").run).toContain("verify-generated");
 	});
@@ -328,10 +338,16 @@ async function providerEvidenceFixture(falseDigest = false, unqualifiedPin = fal
 	const pinDocument = {
 		assets: {
 			"api-catalog.json": pinDigest("1"),
+			"concurrency_contracts.json": pinDigest("6"),
 			[`f5xc-api-specs-${specTag}.zip`]: pinDigest("2"),
 			"index.json": pinDigest("3"),
 			"minimal-export-defaults.json": pinDigest("4"),
 			"openapi.json": pinDigest("5"),
+			"smsv2-contract-manifest.json": pinDigest("7"),
+			"smsv2-contract.json": pinDigest("8"),
+			"smsv2-evidence-receipt.json": pinDigest("9"),
+			"smsv2_parity_manifest.json": pinDigest("a"),
+			"upstream-contract-removals.json": pinDigest("b"),
 		},
 		release_tag: specTag,
 		target_commit: specCommit,

--- a/scripts/api-spec-delivery.ts
+++ b/scripts/api-spec-delivery.ts
@@ -182,10 +182,16 @@ export function validateArtifactVersion(
 function expectedSpecAssetNames(releaseTag: string): string[] {
 	return [
 		"api-catalog.json",
+		"concurrency_contracts.json",
 		`f5xc-api-specs-${releaseTag}.zip`,
 		"index.json",
 		"minimal-export-defaults.json",
 		"openapi.json",
+		"smsv2-contract-manifest.json",
+		"smsv2-contract.json",
+		"smsv2-evidence-receipt.json",
+		"smsv2_parity_manifest.json",
+		"upstream-contract-removals.json",
 	].sort();
 }
 


### PR DESCRIPTION
## Summary

- require the exact immutable 11-asset API v3 release contract
- reject both missing and unexpected assets
- align the provider receipt validator and delivery fixtures with that complete contract

## Clean-break guarantee

This removes the obsolete five-asset receiver assumption. It adds no compatibility fallback, alias, legacy schema, or migration shim.

## Verification

- focused delivery/workflow tests: 30 passed, 0 failed
- `bun run check`: passed
- `bun run test`: 6,723 core passed, 559 skipped, 0 failed; all workspace suites passed
- staged pre-commit hook and `git diff --check`: passed

Closes #3428