### PR TITLE
fix(delivery): preserve sha256-qualified API digests

### DIFF
--- a/packages/coding-agent/test/scripts/api-spec-delivery.test.ts
+++ b/packages/coding-agent/test/scripts/api-spec-delivery.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import {
 	type ApiSpecDelivery,
+	type ApiSpecReleasePin,
 	acknowledgePublishedDelivery,
 	calculateDeliveryId,
 	calculateDeliveryIdForTarget,
@@ -14,6 +15,7 @@ import {
 	deliveryBranch,
 	GENERATED_DELIVERY_PATHS,
 	parseDispatchEvent,
+	parseSpecReleasePin,
 	releaseIdentityFromEnvironment,
 	SPEC_RELEASE_PATH,
 	validateArtifactVersion,
@@ -50,7 +52,7 @@ const XCSH_RELEASE_ASSETS = [
 	"xcsh-windows-x64.exe",
 ] as const;
 
-function specReleasePin(): Record<string, unknown> {
+function specReleasePin(): ApiSpecReleasePin {
 	return {
 		assets: {
 			"api-catalog.json": "1".repeat(64),
@@ -68,6 +70,14 @@ function specReleasePin(): Record<string, unknown> {
 		release_tag: RELEASE_TAG,
 		target_commit: TARGET_COMMIT,
 		version: VERSION,
+	};
+}
+
+function qualifiedSpecReleasePin(): ApiSpecReleasePin {
+	const pin = specReleasePin();
+	return {
+		...pin,
+		assets: Object.fromEntries(Object.entries(pin.assets).map(([name, digest]) => [name, `sha256:${digest}`])),
 	};
 }
 
@@ -105,7 +115,7 @@ async function preparePendingDelivery(repoRoot: string): Promise<Record<string, 
 		await Bun.write(path.join(repoRoot, generatedPath), `generated ${generatedPath}\n`);
 	}
 	const pinPath = path.join(repoRoot, "source-pin.json");
-	await Bun.write(pinPath, `${JSON.stringify(specReleasePin())}\n`);
+	await Bun.write(pinPath, `${JSON.stringify(qualifiedSpecReleasePin())}\n`);
 	await writePendingDelivery(repoRoot, validDelivery(), pinPath, PROVIDER_TAG, PROVIDER_COMMIT);
 	return Bun.file(path.join(repoRoot, DELIVERY_PENDING_PATH)).json();
 }
@@ -284,7 +294,7 @@ describe("durable API spec delivery ledger", () => {
 				await Bun.write(path.join(repoRoot, generatedPath), `generated ${generatedPath}\n`);
 			}
 			const pinPath = path.join(repoRoot, "source-pin.json");
-			await Bun.write(pinPath, `${JSON.stringify(specReleasePin())}\n`);
+			await Bun.write(pinPath, `${JSON.stringify(qualifiedSpecReleasePin())}\n`);
 			await expect(
 				writePendingDelivery(repoRoot, validDelivery(), pinPath, "latest", PROVIDER_COMMIT),
 			).rejects.toThrow("Provider tag must be");
@@ -298,6 +308,25 @@ describe("durable API spec delivery ledger", () => {
 			await expect(
 				verifyGeneratedDelivery(repoRoot, validDelivery(), PROVIDER_TAG, PROVIDER_COMMIT),
 			).rejects.toThrow("differ from pending attestation");
+		} finally {
+			await fs.rm(repoRoot, { force: true, recursive: true });
+		}
+	});
+
+	it("requires and preserves sha256-qualified spec release pins", async () => {
+		expect(() => parseSpecReleasePin(specReleasePin())).toThrow("sha256-qualified");
+		const qualified = qualifiedSpecReleasePin();
+		expect(parseSpecReleasePin(qualified)).toEqual(qualified);
+
+		const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "xcsh-qualified-spec-pin-"));
+		try {
+			for (const generatedPath of GENERATED_DELIVERY_PATHS) {
+				await Bun.write(path.join(repoRoot, generatedPath), `generated ${generatedPath}\n`);
+			}
+			const sourcePin = path.join(repoRoot, "source-pin.json");
+			await Bun.write(sourcePin, `${JSON.stringify(qualified)}\n`);
+			await writePendingDelivery(repoRoot, validDelivery(), sourcePin, PROVIDER_TAG, PROVIDER_COMMIT);
+			expect(await Bun.file(path.join(repoRoot, SPEC_RELEASE_PATH)).json()).toEqual(qualified);
 		} finally {
 			await fs.rm(repoRoot, { force: true, recursive: true });
 		}

--- a/scripts/api-spec-delivery.ts
+++ b/scripts/api-spec-delivery.ts
@@ -236,6 +236,21 @@ function validateQualifiedDigestMap(
 	return validated;
 }
 
+function validateQualifiedSpecDigests(
+	document: unknown,
+	expectedNames: readonly string[],
+	field: string,
+): Record<string, string> {
+	const digests = validateQualifiedDigestMap(document, expectedNames, field);
+	return Object.fromEntries(Object.entries(digests).map(([name, digest]) => [name, `sha256:${digest}`]));
+}
+
+function unqualifiedSha256(digest: string): string {
+	const match = QUALIFIED_SHA256_PATTERN.exec(digest);
+	if (!match) throw new Error("Internal spec-release digest is not sha256-qualified");
+	return match[1];
+}
+
 export function parseSpecReleasePin(document: unknown, delivery?: ApiSpecDelivery): ApiSpecReleasePin {
 	if (!document || typeof document !== "object" || Array.isArray(document)) {
 		throw new Error("Spec release pin must be an object");
@@ -254,7 +269,7 @@ export function parseSpecReleasePin(document: unknown, delivery?: ApiSpecDeliver
 		throw new Error("Spec release pin disagrees with the dispatched identity");
 	}
 	return {
-		assets: validateDigestMap(pin.assets, expectedSpecAssetNames(releaseTag), "spec-release.assets"),
+		assets: validateQualifiedSpecDigests(pin.assets, expectedSpecAssetNames(releaseTag), "spec-release.assets"),
 		release_tag: releaseTag,
 		target_commit: targetCommit,
 		version,
@@ -926,7 +941,9 @@ async function main(): Promise<void> {
 		const receipt = await verifyReleasedTag(delivery, process.env.GITHUB_TOKEN);
 		const pin = parseSpecReleasePin(
 			{
-				assets: receipt.assets,
+				assets: Object.fromEntries(
+					Object.entries(receipt.assets).map(([name, digest]) => [name, `sha256:${digest}`]),
+				),
 				release_tag: delivery.releaseTag,
 				target_commit: receipt.commit,
 				version: receipt.version,
@@ -941,9 +958,9 @@ async function main(): Promise<void> {
 		await fs.appendFile(
 			outputPath,
 			[
-				`bundle_sha256=${pin.assets[bundleName]}`,
-				`catalog_sha256=${pin.assets["api-catalog.json"]}`,
-				`defaults_sha256=${pin.assets["minimal-export-defaults.json"]}`,
+				`bundle_sha256=${unqualifiedSha256(pin.assets[bundleName])}`,
+				`catalog_sha256=${unqualifiedSha256(pin.assets["api-catalog.json"])}`,
+				`defaults_sha256=${unqualifiedSha256(pin.assets["minimal-export-defaults.json"])}`,
 				`pin_path=${pinPath}`,
 			].join("\n") + "\n",
 		);


### PR DESCRIPTION
## Summary

- require exact `sha256:<64-hex>` digests in API release pins
- preserve qualified digests in the durable `tools/spec-release.json` ledger
- strip the qualifier only at the generator CLI boundary
- reject historical bare digests instead of accepting a compatibility form

## Verification

- `bun test packages/coding-agent/test/scripts/api-spec-delivery.test.ts` (17 pass)
- delivery/workflow focused suite (31 pass, 153 expectations)
- `bun run check`
- `bun run test` (6,724 pass, 559 skip, 0 fail)
- Gitleaks operational check confirms qualified digests are not secret findings

Closes #3432