### PR TITLE
fix(coding-agent): model complete API catalog metadata

### DIFF
--- a/packages/coding-agent/src/internal-urls/api-catalog-types.ts
+++ b/packages/coding-agent/src/internal-urls/api-catalog-types.ts
@@ -21,6 +21,7 @@ export interface ApiCatalogMinimumPayload {
 
 export interface ApiCatalogFieldMeta {
 	readonly type: string;
+	readonly wireName?: string;
 	readonly description?: string;
 	readonly required_for?: {
 		readonly minimum_config?: boolean;
@@ -50,6 +51,7 @@ export interface ApiCatalogResponseField {
 
 export interface ApiCatalogOperation {
 	readonly name: string;
+	readonly operationAliases?: readonly string[];
 	readonly description: string;
 	readonly method: string;
 	readonly path: string;

--- a/packages/coding-agent/test/internal-urls/api-catalog-resolve-direct.test.ts
+++ b/packages/coding-agent/test/internal-urls/api-catalog-resolve-direct.test.ts
@@ -28,11 +28,18 @@ const mockCategory: ApiCatalogCategory = {
 	operations: [
 		{
 			name: "Create test",
+			operationAliases: ["ves.io.schema.test.CustomAPI.Create"],
 			description: "Creates a test resource",
 			method: "post",
 			path: "/api/test/{namespace}/resources",
 			dangerLevel: "low",
 			parameters: [],
+			fieldMetadata: {
+				public_name: {
+					type: "string",
+					wireName: "wire_name",
+				},
+			},
 		},
 	],
 };
@@ -61,6 +68,12 @@ describe("createApiCatalogResolver — direct data (no decompression)", () => {
 	it("accepts data as Record<string, ApiCatalogCategory> instead of blobs", () => {
 		const resolver = createApiCatalogResolver(mockIndex, mockSummaries, mockData);
 		expect(resolver).toBeDefined();
+	});
+
+	it("preserves exact wire-name and operation-alias metadata without resolving aliases", () => {
+		const operation = mockCategory.operations[0];
+		expect(operation.operationAliases).toEqual(["ves.io.schema.test.CustomAPI.Create"]);
+		expect(operation.fieldMetadata?.public_name?.wireName).toBe("wire_name");
 	});
 
 	it("resolves a category from data directly", async () => {


### PR DESCRIPTION
## Summary

- model canonical field `wireName` metadata in the closed catalog type
- model source operation aliases as descriptive readonly metadata only
- add no alias resolution, compatibility lookup, fallback parsing, or open index signature
- compile the exact v3.0.0 generated index without changing generated bytes

## Verification

- focused resolver test: 3 pass, 0 fail
- `bun --cwd=packages/coding-agent run check:types`
- `bun run ci:check:full`
- Gitleaks: no leaks in 132.52 MB
- full suite currently has one expected pre-existing failure: the immutable v3.0.0 input contains deprecated `docs-v2/api` receipt provenance; f5-sales-demo/api-specs-enriched#1633 removes it at source and its focused tests are green

Closes #3436