### PR TITLE
fix(delivery): compare provider spec pins structurally

### DIFF
--- a/.github/workflows/api-spec-update.yml
+++ b/.github/workflows/api-spec-update.yml
@@ -281,10 +281,10 @@ jobs:
                   echo "::error::Provider release carries a malformed or mismatched spec pin"
                   exit 1
                 }
-                PROVIDER_NORMALIZED_PIN=$(jq -cS '
-                  .assets |= with_entries(.value |= sub("^sha256:"; ""))
-                ' "$RUNNER_TEMP/provider-spec-release.json")
-                [ "$PROVIDER_NORMALIZED_PIN" = "$(jq -cS . "$SOURCE_PIN_FILE")" ] || {
+                jq -e --slurpfile source "$SOURCE_PIN_FILE" '
+                  ($source | length) == 1 and
+                  ((.assets |= with_entries(.value |= sub("^sha256:"; ""))) == $source[0])
+                ' "$RUNNER_TEMP/provider-spec-release.json" >/dev/null || {
                   echo "::error::Provider release consumed different spec bytes from this receiver"
                   exit 1
                 }

--- a/packages/coding-agent/test/scripts/api-spec-update-workflow.test.ts
+++ b/packages/coding-agent/test/scripts/api-spec-update-workflow.test.ts
@@ -123,6 +123,13 @@ describe("API spec dispatch workflow contract", () => {
 		expect(namedStep(steps, "Verify exact regenerated delivery bytes").run).toContain("verify-generated");
 	});
 
+	it("compares normalized provider and source pins structurally", async () => {
+		const provider = namedStep(await workflowSteps(), "Resolve exact published provider release").run ?? "";
+		expect(provider).toContain('--slurpfile source "$SOURCE_PIN_FILE"');
+		expect(provider).toContain("== $source[0]");
+		expect(provider).not.toContain('[ "$PROVIDER_NORMALIZED_PIN" =');
+	});
+
 	it("records pending identity only after verification and resumes an existing branch and PR", async () => {
 		const steps = await workflowSteps();
 		const names = steps.map(step => step.name ?? "");


### PR DESCRIPTION
## Summary

Replace the Actions-only Bash scalar comparison with one structural jq comparison after strict provider digest normalization. This removes the false negative seen twice in run 33160020192 without weakening release identity, asset-set, digest, receipt, or immutable-tag validation.

## Related Issue

Closes #3440

## Changes

- compare the exact provider and source pin JSON structures inside jq
- require exactly one parsed source document
- add a regression that forbids the shell scalar comparison
- retain the existing mismatch fixture and every preceding validation gate

## Verification evidence

- TDD red: focused workflow test failed against the Bash comparison
- `bun test packages/coding-agent/test/scripts/api-spec-update-workflow.test.ts --max-concurrency 2` — 15 passed, 0 failed
- live immutable API v4/provider v5 pin structural comparison — passed
- `bun run check` — passed
- targeted `pre-commit` — all applicable hooks passed, including YAML, Actions lint/security, Biome, secrets, and hygiene
- `git diff --check` — passed

## Delivery evidence

- failed receiver run: https://github.com/f5-sales-demo/xcsh/actions/runs/33160020192
- exact v4 delivery will be replayed only after this PR reaches `main`

## Checklist

- [x] Linked to a detailed issue with `Closes #N`
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue acceptance criteria are met
- [x] Verified locally by running the exact immutable pin comparison
- [ ] Pending, failed, behind, or conflicted states repaired through `MERGED`
- [ ] Worktree and confirmed-merged branch cleaned after delivery
- [x] Follows project conventions and style guides