### PR TITLE
fix(delivery): require qualified spec pin equality

### DIFF
--- a/.github/workflows/api-spec-update.yml
+++ b/.github/workflows/api-spec-update.yml
@@ -283,7 +283,7 @@ jobs:
                 }
                 jq -e --slurpfile source "$SOURCE_PIN_FILE" '
                   ($source | length) == 1 and
-                  ((.assets |= with_entries(.value |= sub("^sha256:"; ""))) == $source[0])
+                  (. == $source[0])
                 ' "$RUNNER_TEMP/provider-spec-release.json" >/dev/null || {
                   echo "::error::Provider release consumed different spec bytes from this receiver"
                   exit 1

--- a/packages/coding-agent/test/scripts/api-spec-update-workflow.test.ts
+++ b/packages/coding-agent/test/scripts/api-spec-update-workflow.test.ts
@@ -123,10 +123,11 @@ describe("API spec dispatch workflow contract", () => {
 		expect(namedStep(steps, "Verify exact regenerated delivery bytes").run).toContain("verify-generated");
 	});
 
-	it("compares normalized provider and source pins structurally", async () => {
+	it("compares canonical qualified provider and source pins directly", async () => {
 		const provider = namedStep(await workflowSteps(), "Resolve exact published provider release").run ?? "";
 		expect(provider).toContain('--slurpfile source "$SOURCE_PIN_FILE"');
-		expect(provider).toContain("== $source[0]");
+		expect(provider).toContain(". == $source[0]");
+		expect(provider).not.toContain('sub("^sha256:"');
 		expect(provider).not.toContain('[ "$PROVIDER_NORMALIZED_PIN" =');
 	});
 
@@ -246,12 +247,28 @@ describe("provider publication evidence gate", () => {
 		}
 	}, 60_000);
 
+	it("rejects an unqualified source pin instead of accepting a legacy encoding", async () => {
+		const fixture = await providerEvidenceFixture();
+		try {
+			const sourcePin = await Bun.file(fixture.env.SOURCE_PIN_FILE).json();
+			for (const [name, digest] of Object.entries(sourcePin.assets as Record<string, string>)) {
+				sourcePin.assets[name] = digest.replace(/^sha256:/, "");
+			}
+			await Bun.write(fixture.env.SOURCE_PIN_FILE, `${JSON.stringify(sourcePin)}\n`);
+			const result = await runProviderEvidenceStep(fixture);
+			expect(result.exitCode).not.toBe(0);
+			expect(result.output).toContain("Provider release consumed different spec bytes from this receiver");
+		} finally {
+			await fs.rm(fixture.root, { force: true, recursive: true });
+		}
+	}, 60_000);
+
 	it("rejects a provider spec pin whose underlying digest differs from the source", async () => {
 		const fixture = await providerEvidenceFixture();
 		try {
 			const sourcePin = await Bun.file(fixture.env.SOURCE_PIN_FILE).json();
 			const assetName = Object.keys(sourcePin.assets)[0];
-			sourcePin.assets[assetName] = "0".repeat(64);
+			sourcePin.assets[assetName] = `sha256:${"0".repeat(64)}`;
 			await Bun.write(fixture.env.SOURCE_PIN_FILE, `${JSON.stringify(sourcePin)}\n`);
 			const result = await runProviderEvidenceStep(fixture);
 			expect(result.exitCode).not.toBe(0);
@@ -364,12 +381,7 @@ async function providerEvidenceFixture(falseDigest = false, unqualifiedPin = fal
 		version: specVersion,
 	};
 	const pin = `${JSON.stringify(pinDocument)}\n`;
-	const sourcePin = `${JSON.stringify({
-		...pinDocument,
-		assets: Object.fromEntries(
-			Object.entries(pinDocument.assets).map(([name, digest]) => [name, digest.replace(/^sha256:/, "")]),
-		),
-	})}\n`;
+	const sourcePin = `${JSON.stringify(pinDocument)}\n`;
 	const pinSha = new Bun.CryptoHasher("sha256").update(pin).digest("hex");
 	const assets = Object.fromEntries(
 		providerAssetNames(providerVersion).map((name, index) => [


### PR DESCRIPTION
## Summary

Require direct structural equality between the canonical qualified API and provider spec pins. The prior provider gate stripped `sha256:` while the canonical receiver now preserves it, making every exact v4 digest compare unequal. This follow-up removes normalization completely; it does not accept the retired unqualified encoding.

## Related Issue

Closes #3440

## Changes

- compare qualified provider/source pin documents directly
- remove digest normalization and dual-encoding behavior
- make the happy-path fixture qualified
- add explicit rejection coverage for an unqualified source pin
- retain mismatch, identity, release, receipt, and asset-set guards

## Verification evidence

- TDD red: canonical-qualified happy path and unqualified-source rejection failed against the normalizing gate
- `bun test packages/coding-agent/test/scripts/api-spec-update-workflow.test.ts --max-concurrency 2` — 16 passed, 0 failed
- actual Bun-generated API v4 pin versus provider-v5 immutable pin — direct qualified equality passed
- `bun run check` — passed
- targeted `pre-commit` — all applicable hooks passed, including Actions lint/security and secrets detection
- `git diff --check` — passed

## Delivery evidence

- root-cause run: https://github.com/f5-sales-demo/xcsh/actions/runs/33160997618
- exact v4 delivery will be freshly dispatched after merge

## Checklist

- [x] Linked to detailed reopened issue #3440
- [x] Feature-complete and verified
- [x] Tests written first and passing
- [x] Live immutable pin equality exercised
- [ ] Repair loop completed through `MERGED`
- [ ] Worktree cleaned after delivery
- [x] No compatibility path or legacy encoding accepted