### PR TITLE
fix(plugin): keep marketplace dry-runs immutable

### DIFF
--- a/packages/coding-agent/src/cli/plugin-cli.ts
+++ b/packages/coding-agent/src/cli/plugin-cli.ts
@@ -425,6 +425,17 @@ async function handleInstall(
 		}
 
 		if (target.type === "marketplace") {
+			if (flags.dryRun) {
+				const preview = {
+					action: "install",
+					target: `${target.name}@${target.marketplace}`,
+					scope: flags.scope ?? "user",
+					dryRun: true,
+				};
+				if (flags.json) console.log(JSON.stringify(preview, null, 2));
+				else console.log(chalk.dim(`[dry-run] Would install ${preview.target} (${preview.scope})`));
+				continue;
+			}
 			try {
 				const entry = await mktMgr.installPlugin(target.name, target.marketplace, {
 					force: flags.force,

--- a/packages/coding-agent/test/marketplace/plugin-dry-run.test.ts
+++ b/packages/coding-agent/test/marketplace/plugin-dry-run.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { createHash } from "node:crypto";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const roots: string[] = [];
+afterEach(() => {
+	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+function digest(root: string): string {
+	const hash = createHash("sha256");
+	function visit(path: string): void {
+		if (!existsSync(path)) return;
+		for (const name of readdirSync(path).sort()) {
+			const child = join(path, name);
+			const stat = statSync(child);
+			hash.update(name);
+			if (stat.isDirectory()) visit(child);
+			else hash.update(readFileSync(child));
+		}
+	}
+	visit(root);
+	return hash.digest("hex");
+}
+
+describe("plugin install dry-run", () => {
+	it("does not change marketplace plugin registry or cache", () => {
+		const root = mkdtempSync(join(tmpdir(), "xcsh-plugin-dry-run-"));
+		roots.push(root);
+		const repository = resolve(import.meta.dir, "../../../..");
+		const cli = join(repository, "packages/coding-agent/src/cli.ts");
+		const fixture = join(repository, "packages/coding-agent/test/marketplace/fixtures/valid-marketplace");
+		const environment = { ...process.env, HOME: root };
+		const added = Bun.spawnSync(["bun", cli, "plugin", "marketplace", "add", fixture], {
+			cwd: repository,
+			env: environment,
+		});
+		expect(added.exitCode).toBe(0);
+		const before = digest(root);
+		const preview = Bun.spawnSync(
+			["bun", cli, "plugin", "install", "hello-plugin@test-marketplace", "--dry-run", "--json"],
+			{ cwd: repository, env: environment, stdout: "pipe", stderr: "pipe" },
+		);
+		expect(preview.exitCode).toBe(0);
+		expect(JSON.parse(new TextDecoder().decode(preview.stdout))).toEqual({
+			action: "install",
+			target: "hello-plugin@test-marketplace",
+			scope: "user",
+			dryRun: true,
+		});
+		expect(digest(root)).toBe(before);
+		expect(existsSync(join(root, ".xcsh/plugins/installed_plugins.json"))).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

- make marketplace plugin install dry-runs return before mutation
- emit structured JSON or text preview output
- add a subprocess regression proving registry and cache immutability

## Validation

- `bun test` for marketplace CLI, manager, and dry-run regression: 58 passed
- `bun run check:types`
- AGY reviewer and verifier: approved, no findings

Closes #3454