### PR TITLE
fix(plugin): let explicit directories shadow installs

### DIFF
--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -843,17 +843,31 @@ export async function listXcshPluginRoots(
 		roots.push(...projectRoots, ...deduped);
 	}
 
-	// Merge --plugin-dir roots (highest precedence) on every fresh load
+	// Merge --plugin-dir roots (highest precedence) on every fresh load. Local roots use
+	// an artificial marketplace ID, so identity must be matched by manifest plugin name;
+	// comparing full IDs would leave the installed copy active beside the candidate.
 	if (injectedPluginDirRoots.length > 0) {
-		const injectedIds = new Set(injectedPluginDirRoots.map(r => r.id));
-		const filtered = roots.filter(r => !injectedIds.has(r.id));
+		const merged = prioritizeInjectedPluginRoots(roots, injectedPluginDirRoots);
 		roots.length = 0;
-		roots.push(...injectedPluginDirRoots, ...filtered);
+		roots.push(...merged);
 	}
 
 	const result = { roots, warnings };
 	pluginRootsCache.set(cacheKey, result);
 	return result;
+}
+
+export function prioritizeInjectedPluginRoots(
+	installed: XcshPluginRoot[],
+	injected: XcshPluginRoot[],
+): XcshPluginRoot[] {
+	const seen = new Set<string>();
+	const winners = injected.filter(root => {
+		if (seen.has(root.plugin)) return false;
+		seen.add(root.plugin);
+		return true;
+	});
+	return [...winners, ...installed.filter(root => !seen.has(root.plugin))];
 }
 
 export interface XcshPluginSummary {

--- a/packages/coding-agent/test/marketplace/plugin-dir-shadow.test.ts
+++ b/packages/coding-agent/test/marketplace/plugin-dir-shadow.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { prioritizeInjectedPluginRoots } from "../../src/discovery/helpers";
+import type { XcshPluginRoot } from "../../src/discovery/types";
+
+function root(plugin: string, marketplace: string, path: string): XcshPluginRoot {
+	return { id: `${plugin}@${marketplace}`, plugin, marketplace, path, version: "1.0.0", scope: "user" };
+}
+
+describe("--plugin-dir precedence", () => {
+	test("an explicit plugin shadows installed copies by manifest identity", () => {
+		const installed = [root("asm-migration", "marketplace", "/installed"), root("other", "marketplace", "/other")];
+		const injected = [root("asm-migration", "__local__", "/candidate")];
+		expect(prioritizeInjectedPluginRoots(installed, injected)).toEqual([injected[0], installed[1]]);
+	});
+
+	test("the first explicit directory wins duplicate identities deterministically", () => {
+		const first = root("same", "__local__", "/first");
+		const second = root("same", "__local__", "/second");
+		expect(prioritizeInjectedPluginRoots([], [first, second])).toEqual([first]);
+	});
+});

--- a/packages/coding-agent/test/marketplace/plugin-dir-shadow.test.ts
+++ b/packages/coding-agent/test/marketplace/plugin-dir-shadow.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { prioritizeInjectedPluginRoots } from "../../src/discovery/helpers";
-import type { XcshPluginRoot } from "../../src/discovery/types";
+import { prioritizeInjectedPluginRoots, type XcshPluginRoot } from "../../src/discovery/helpers";
 
 function root(plugin: string, marketplace: string, path: string): XcshPluginRoot {
 	return { id: `${plugin}@${marketplace}`, plugin, marketplace, path, version: "1.0.0", scope: "user" };


### PR DESCRIPTION
## Summary

- deduplicate explicit and installed plugin roots by manifest plugin identity
- give the first explicit `--plugin-dir` highest deterministic precedence
- keep unrelated installed plugins available
- add focused regression coverage

## Validation

- discovery and plugin-dir tests: 24 passed
- `bun run check:types`
- AGY reviewer and verifier: approved, no findings after remediation

Closes #3456
