### PR TITLE
fix(sandbox): align self-test with Seatbelt isolation

### DIFF
--- a/packages/coding-agent/src/cli/sandbox-check.ts
+++ b/packages/coding-agent/src/cli/sandbox-check.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { executeShell, fencePermits } from "@f5-sales-demo/pi-natives";
-import { isEnoent } from "@f5-sales-demo/pi-utils";
+import { isEnoent, pathIsWithin } from "@f5-sales-demo/pi-utils";
 import { Settings } from "../config/settings";
 import { fenceForNative } from "../exec/bash-executor";
 import { buildContainmentFence, type ContainmentFence, containmentStatus, fenceVerdict } from "../sandbox/containment";
@@ -462,7 +462,7 @@ export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promis
 			);
 		});
 
-		await check("named sibling remains reachable", async () => {
+		await check("named sibling follows the active boundary", async () => {
 			const displayPath = "<session-parent>/<synthetic-sibling>";
 			let liveSibling = inheritedSibling;
 			if (liveSibling === undefined) {
@@ -480,13 +480,23 @@ export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promis
 					return exceptionOutcome("create named sibling fixture", displayPath, error, redactions);
 				}
 			}
+			const seatbeltDeniesSibling =
+				backend.backend === "seatbelt" && liveFence.denyOnSeatbelt.some(root => pathIsWithin(root, liveSibling));
 			const result = await shellProbe(
-				'test "$(cat named.txt)" = sibling',
-				liveSibling,
-				undefined,
+				`cd ${quote(liveSibling)} && test "$(cat named.txt)" = sibling`,
+				liveWorkspace,
+				inheritedProfile ? undefined : liveFence,
 				abortController.signal,
 			);
-			return shellOutcome(result, true, "live profile must allow a named sibling read", displayPath, redactions);
+			return shellOutcome(
+				result,
+				!seatbeltDeniesSibling,
+				seatbeltDeniesSibling
+					? "Seatbelt must deny a named sibling outside the workspace"
+					: "live profile must allow a named sibling read",
+				displayPath,
+				redactions,
+			);
 		});
 
 		if (backend.osEnforced) {

--- a/packages/coding-agent/test/sandbox-check.test.ts
+++ b/packages/coding-agent/test/sandbox-check.test.ts
@@ -94,6 +94,10 @@ function assertHealthyReport(report: SandboxCheckReport): void {
 	expect(report.checks).toContainEqual({ name: "operator home remains enumerable", status: "PASS" });
 	expect(report.checks).toContainEqual({ name: "filesystem root remains enumerable", status: "PASS" });
 	expect(report.checks).toContainEqual({ name: "operator home supports direct file creation", status: "PASS" });
+	expect(report.checks).toContainEqual({
+		name: "named sibling follows the active boundary",
+		status: "PASS",
+	});
 	expect(report.checks).toContainEqual({ name: "synthetic fixtures removed", status: "PASS" });
 	if (report.osEnforced) {
 		expect(report.summary).toEqual({ passed: 17, failed: 0, errors: 0, skipped: 0 });


### PR DESCRIPTION
## Summary

- align the live sandbox diagnostic with the Seatbelt sibling-customer boundary introduced by #3459
- run the sibling probe from the allowed workspace so an expected denial is observed as an exit result rather than a setup exception
- retain named-sibling reachability for Landlock, scanner-only sessions, and workspaces directly under operator home
- assert the backend-aware diagnostic remains part of the healthy conformance report

## Validation

- `bun test packages/coding-agent/test/sandbox-check.test.ts packages/coding-agent/test/sandbox-isolation.test.ts` (28 passed)
- `bun run check`
- `bun run lint`
- `bun run pii:gate`
- AGY reviewer and independent verifier: approved, zero findings

Closes #3462