### PR TITLE
fix(sandbox): align inherited Seatbelt expectation

### DIFF
--- a/packages/coding-agent/src/cli/sandbox-check.ts
+++ b/packages/coding-agent/src/cli/sandbox-check.ts
@@ -3,13 +3,20 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { executeShell, fencePermits } from "@f5-sales-demo/pi-natives";
-import { isEnoent, pathIsWithin } from "@f5-sales-demo/pi-utils";
+import { isEnoent } from "@f5-sales-demo/pi-utils";
 import { Settings } from "../config/settings";
 import { fenceForNative } from "../exec/bash-executor";
-import { buildContainmentFence, type ContainmentFence, containmentStatus, fenceVerdict } from "../sandbox/containment";
+import {
+	buildContainmentFence,
+	type ContainmentFence,
+	containmentStatus,
+	fenceVerdict,
+	seatbeltFenceVerdict,
+} from "../sandbox/containment";
 import { evaluateToolCall } from "../sandbox/enforce";
 import {
 	SANDBOX_CHECK_NAMED_SIBLING_ENV,
+	SANDBOX_CHECK_NAMED_SIBLING_EXPECTATION_ENV,
 	SANDBOX_OPERATOR_HOME_ENV,
 	SANDBOX_SESSION_ROOT_ENV,
 	sandboxCheckSiblingRoot,
@@ -72,6 +79,13 @@ function sanitizeDetail(value: string, redactions: readonly Redaction[]): string
 	}
 	sanitized = sanitized.replace(/\s+/gu, " ").trim();
 	return sanitized.length > 500 ? `${sanitized.slice(0, 497)}...` : sanitized;
+}
+
+function inheritedNamedSiblingDenied(value: string | undefined): boolean | undefined {
+	if (value === undefined) return undefined;
+	if (value === "denied") return true;
+	if (value === "allowed") return false;
+	throw new Error(`invalid ${SANDBOX_CHECK_NAMED_SIBLING_EXPECTATION_ENV}: expected "allowed" or "denied"`);
 }
 
 function errnoFromOutput(output: string): string {
@@ -210,6 +224,10 @@ export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promis
 		const inheritedHome = process.env[SANDBOX_OPERATOR_HOME_ENV];
 		const inheritedSibling = process.env[SANDBOX_CHECK_NAMED_SIBLING_ENV];
 		const inheritedProfile = inheritedWorkspace !== undefined;
+		const inheritedSiblingDenied =
+			inheritedProfile && inheritedSibling !== undefined
+				? inheritedNamedSiblingDenied(process.env[SANDBOX_CHECK_NAMED_SIBLING_EXPECTATION_ENV])
+				: undefined;
 		const workspaceInput = inheritedWorkspace ?? process.cwd();
 		const homeInput = inheritedHome ?? os.homedir();
 		redactions.push([workspaceInput, "<workspace>"], [homeInput, "<operator-home>"]);
@@ -481,7 +499,8 @@ export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promis
 				}
 			}
 			const seatbeltDeniesSibling =
-				backend.backend === "seatbelt" && liveFence.denyOnSeatbelt.some(root => pathIsWithin(root, liveSibling));
+				inheritedSiblingDenied ??
+				(backend.backend === "seatbelt" && seatbeltFenceVerdict(liveFence, liveSibling, "read") === "deny");
 			const result = await shellProbe(
 				`cd ${quote(liveSibling)} && test "$(cat named.txt)" = sibling`,
 				liveWorkspace,

--- a/packages/coding-agent/src/sandbox/containment.ts
+++ b/packages/coding-agent/src/sandbox/containment.ts
@@ -606,6 +606,12 @@ export function fenceVerdict(fence: ContainmentFence, candidate: string, access:
 	return "allow";
 }
 
+/** Apply the same deepest-rule precedence used by the native macOS Seatbelt profile. */
+export function seatbeltFenceVerdict(fence: ContainmentFence, candidate: string, access: FenceAccess): FenceVerdict {
+	if (fence.denyOnSeatbelt.length === 0) return fenceVerdict(fence, candidate, access);
+	return fenceVerdict({ ...fence, deny: [...fence.deny, ...fence.denyOnSeatbelt] }, candidate, access);
+}
+
 /** Which mechanism is actually enforcing the boundary for the `bash` tool. */
 export type ContainmentBackend = "seatbelt" | "landlock" | "scanner-only" | "disabled";
 

--- a/packages/coding-agent/src/sandbox/session-fence.ts
+++ b/packages/coding-agent/src/sandbox/session-fence.ts
@@ -28,6 +28,7 @@ import { buildContainmentFence, type ContainmentFence } from "./containment";
 export const SANDBOX_SESSION_ROOT_ENV = "XCSH_SANDBOX_SESSION_ROOT";
 export const SANDBOX_OPERATOR_HOME_ENV = "XCSH_SANDBOX_OPERATOR_HOME";
 export const SANDBOX_CHECK_NAMED_SIBLING_ENV = "XCSH_SANDBOX_CHECK_NAMED_SIBLING";
+export const SANDBOX_CHECK_NAMED_SIBLING_EXPECTATION_ENV = "XCSH_SANDBOX_CHECK_NAMED_SIBLING_EXPECTATION";
 
 /** Choose a writable root for the live named-path probe without escaping an operator-home session. */
 export function sandboxCheckSiblingRoot(workspace: string, operatorHome: string): string {

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -18,10 +18,11 @@ import { resolveLocalRoot } from "../internal-urls/local-protocol";
 import { truncateToVisualLines } from "../modes/components/visual-truncate";
 import type { Theme } from "../modes/theme/theme";
 import bashDescription from "../prompts/tools/bash.md" with { type: "text" };
-import { type ContainmentFence, fenceVerdict } from "../sandbox/containment";
+import { type ContainmentFence, fenceVerdict, seatbeltFenceVerdict } from "../sandbox/containment";
 import {
 	resolveSessionFence,
 	SANDBOX_CHECK_NAMED_SIBLING_ENV,
+	SANDBOX_CHECK_NAMED_SIBLING_EXPECTATION_ENV,
 	SANDBOX_OPERATOR_HOME_ENV,
 	SANDBOX_SESSION_ROOT_ENV,
 	sandboxCheckSiblingRoot,
@@ -806,7 +807,15 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 				),
 			);
 			await Bun.write(path.join(sandboxCheckSibling, "named.txt"), "sibling\n");
-			env = { ...env, [SANDBOX_CHECK_NAMED_SIBLING_ENV]: sandboxCheckSibling };
+			const namedSiblingExpectation =
+				process.platform === "darwin" && seatbeltFenceVerdict(fence, sandboxCheckSibling, "read") === "deny"
+					? "denied"
+					: "allowed";
+			env = {
+				...env,
+				[SANDBOX_CHECK_NAMED_SIBLING_ENV]: sandboxCheckSibling,
+				[SANDBOX_CHECK_NAMED_SIBLING_EXPECTATION_ENV]: namedSiblingExpectation,
+			};
 		}
 
 		let result: BashResult | BashInteractiveResult;

--- a/packages/coding-agent/test/sandbox-check.test.ts
+++ b/packages/coding-agent/test/sandbox-check.test.ts
@@ -9,6 +9,7 @@ import { Settings } from "../src/config/settings";
 import { _resetShellSessionsForTest } from "../src/exec/bash-executor";
 import {
 	SANDBOX_CHECK_NAMED_SIBLING_ENV,
+	SANDBOX_CHECK_NAMED_SIBLING_EXPECTATION_ENV,
 	SANDBOX_OPERATOR_HOME_ENV,
 	SANDBOX_SESSION_ROOT_ENV,
 } from "../src/sandbox/session-fence";
@@ -70,6 +71,7 @@ async function runInsideLiveProfile(
 		...(attemptContextOverride
 			? {
 					env: {
+						[SANDBOX_CHECK_NAMED_SIBLING_EXPECTATION_ENV]: "denied",
 						[SANDBOX_CHECK_NAMED_SIBLING_ENV]: path.join(workspace, "bogus-sibling"),
 						[SANDBOX_SESSION_ROOT_ENV]: path.join(workspace, "bogus-root"),
 						[SANDBOX_OPERATOR_HOME_ENV]: path.join(workspace, "bogus-home"),
@@ -107,12 +109,18 @@ function assertHealthyReport(report: SandboxCheckReport): void {
 	}
 }
 
+function assertHealthyProcessResult(result: $.ShellOutput, report: SandboxCheckReport): void {
+	if (result.exitCode !== 0) {
+		throw new Error(`sandbox check exited ${result.exitCode}:\n${JSON.stringify(report, null, 2)}`);
+	}
+	assertHealthyReport(report);
+}
+
 it("runs the flag-free sandbox check named by launch-flag diagnostics and verifies fixture cleanup", async () => {
 	const result = await runSandboxCheckProcess(["--json"]);
 	const report = JSON.parse(result.stdout.toString()) as SandboxCheckReport;
 
-	expect(result.exitCode).toBe(0);
-	assertHealthyReport(report);
+	assertHealthyProcessResult(result, report);
 }, 30_000);
 
 it("reports a healthy matrix when invoked from operator home", async () => {
@@ -120,9 +128,47 @@ it("reports a healthy matrix when invoked from operator home", async () => {
 	const result = await runSandboxCheckProcess(["--json"], process.env, home);
 	const report = JSON.parse(result.stdout.toString()) as SandboxCheckReport;
 
-	expect(result.exitCode).toBe(0);
-	assertHealthyReport(report);
+	assertHealthyProcessResult(result, report);
 }, 30_000);
+
+it("uses the host expectation for a named sibling in an inherited profile", async () => {
+	const container = fs.realpathSync(fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "sandbox-check-expect-")));
+	const workspace = path.join(container, "workspace");
+	const sibling = path.join(container, "sibling");
+	fs.mkdirSync(workspace);
+	fs.mkdirSync(sibling);
+	fs.writeFileSync(path.join(sibling, "named.txt"), "sibling\n");
+
+	try {
+		const inheritedEnv = {
+			...process.env,
+			[SANDBOX_SESSION_ROOT_ENV]: workspace,
+			[SANDBOX_OPERATOR_HOME_ENV]: container,
+			[SANDBOX_CHECK_NAMED_SIBLING_ENV]: sibling,
+		};
+		const deniedResult = await runSandboxCheckProcess(["--json"], {
+			...inheritedEnv,
+			[SANDBOX_CHECK_NAMED_SIBLING_EXPECTATION_ENV]: "denied",
+		});
+		const deniedReport = JSON.parse(deniedResult.stdout.toString()) as SandboxCheckReport;
+		const namedSibling = deniedReport.checks.find(
+			check => check.name === "named sibling follows the active boundary",
+		);
+
+		expect(deniedResult.exitCode).toBe(1);
+		expect(namedSibling?.status).toBe("FAIL");
+		expect(namedSibling?.detail).toContain("Seatbelt must deny a named sibling outside the workspace");
+
+		const allowedResult = await runSandboxCheckProcess(["--json"], {
+			...inheritedEnv,
+			[SANDBOX_CHECK_NAMED_SIBLING_EXPECTATION_ENV]: "allowed",
+		});
+		const allowedReport = JSON.parse(allowedResult.stdout.toString()) as SandboxCheckReport;
+		assertHealthyProcessResult(allowedResult, allowedReport);
+	} finally {
+		fs.rmSync(container, { recursive: true, force: true });
+	}
+}, 60_000);
 
 it("rejects launch flags on either side of the installed sandbox subcommand with one scope diagnostic", async () => {
 	const home = fs.realpathSync(os.homedir());

--- a/packages/coding-agent/test/sandbox-containment.test.ts
+++ b/packages/coding-agent/test/sandbox-containment.test.ts
@@ -3,7 +3,12 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { getAgentDir, getConfigRootDir, getPluginsDir } from "@f5-sales-demo/pi-utils";
-import { buildContainmentFence, containmentStatus, fenceVerdict } from "../src/sandbox/containment";
+import {
+	buildContainmentFence,
+	containmentStatus,
+	fenceVerdict,
+	seatbeltFenceVerdict,
+} from "../src/sandbox/containment";
 
 /**
  * The fence is deliberately *gentle*: the only thing it prevents is the assistant wandering the
@@ -57,7 +62,9 @@ describe("buildContainmentFence", () => {
 		expect(fenceVerdict(fence, path.join(home, "GIT"), "enumerate")).toBe("deny");
 		expect(fenceVerdict(fence, path.join(home, "GIT", "custB", "secret"), "read")).toBe("allow");
 		expect(fenceVerdict(fence, path.join(home, "GIT", "custB", "secret"), "write")).toBe("allow");
+		expect(seatbeltFenceVerdict(fence, path.join(home, "GIT", "custB", "secret"), "read")).toBe("deny");
 		expect(fenceVerdict(fence, path.join(workspace, "notes.md"), "read")).toBe("allow");
+		expect(seatbeltFenceVerdict(fence, path.join(workspace, "notes.md"), "read")).toBe("allow");
 		expect(fenceVerdict(fence, path.join(workspace, "notes.md"), "write")).toBe("allow");
 		expect(fenceVerdict(fence, workspace, "enumerate")).toBe("allow");
 	});
@@ -75,6 +82,8 @@ describe("buildContainmentFence", () => {
 		expect(fence.denyOnSeatbelt).toContain(parent);
 		expect(fence.allow).toContain(workspace);
 		expect(fence.allow).toContain(trusted);
+		expect(seatbeltFenceVerdict(fence, path.join(trusted, "handoff.txt"), "read")).toBe("allow");
+		expect(seatbeltFenceVerdict(fence, path.join(parent, "example-b", "secret.txt"), "read")).toBe("deny");
 	});
 
 	it("leaves everything outside home alone — nothing operational is restricted", () => {


### PR DESCRIPTION
## Summary

- propagate the outer BashTool profile's exact named-sibling expectation into inherited `sandbox check` diagnostics
- model Seatbelt's shallow-to-deep rule precedence so workspace and trusted grants override broader customer-container denies
- make standalone sandbox-check failures include the full JSON report
- cover inherited expectations, hostile environment overrides, sibling denial, workspace access, and trusted grants

## Validation

- `bun test packages/coding-agent/test/sandbox*.test.ts --max-concurrency 2` — 211 passed
- `bun run check` — passed
- `bun run lint` — passed
- `bun run test` — 8,482 passed, 0 failed across all packages
- `bun run pii:gate` — clean
- `bash scripts/agy-review.sh code --base origin/main` — reviewer and verifier approved with zero findings

## Acceptance

The macOS native-build live-profile self-test and dedicated Seatbelt sibling enforcement step must both pass before merge.

Closes #3466
Follow-up to #3462 and #2621.