### PR TITLE
test(sandbox): scope inherited expectation probe

### DIFF
--- a/packages/coding-agent/test/sandbox-check.test.ts
+++ b/packages/coding-agent/test/sandbox-check.test.ts
@@ -164,7 +164,13 @@ it("uses the host expectation for a named sibling in an inherited profile", asyn
 			[SANDBOX_CHECK_NAMED_SIBLING_EXPECTATION_ENV]: "allowed",
 		});
 		const allowedReport = JSON.parse(allowedResult.stdout.toString()) as SandboxCheckReport;
-		assertHealthyProcessResult(allowedResult, allowedReport);
+		const allowedSibling = allowedReport.checks.find(
+			check => check.name === "named sibling follows the active boundary",
+		);
+		expect(allowedSibling).toEqual({
+			name: "named sibling follows the active boundary",
+			status: "PASS",
+		});
 	} finally {
 		fs.rmSync(container, { recursive: true, force: true });
 	}


### PR DESCRIPTION
## Summary

- limit the synthetic unconfined inherited-environment test to its named-sibling expectation
- retain full 17-check assertions in tests that actually run inside BashTool confinement
- unblock the dedicated macOS Seatbelt enforcement step after PR #3469

## Validation

- focused sandbox-check suite: 10 passed
- bun run check
- bun run lint
- full workspace suite: 8,471 passed, 0 failed
- bun run pii:gate
- two independent AGY reviews: approved with zero findings

Closes #3470

Follow-up to #3466 and #3469.