### PR TITLE
fix(sandbox): enforce Seatbelt denies in shell process

### DIFF
--- a/crates/brush-core-vendored/src/containment.rs
+++ b/crates/brush-core-vendored/src/containment.rs
@@ -210,6 +210,38 @@ impl ContainmentFence {
 		self.permits_resolved(&canonicalize_for_fence(candidate), access)
 	}
 
+	/// Whether this host's in-process shell may access `candidate` for `access`.
+	///
+	/// macOS must include the Seatbelt-only recursive denies because redirects, glob expansion, and
+	/// builtins execute in the agent process rather than in a `sandbox-exec` child. Other platforms
+	/// retain the portable policy: Landlock deliberately does not receive these macOS-only rules.
+	#[must_use]
+	pub fn permits_for_host(&self, candidate: &Path, access: FenceAccess) -> bool {
+		self.permits_resolved_for_host(&canonicalize_for_fence(candidate), access)
+	}
+
+	/// Host-aware variant of [`Self::permits_resolved`] for an already resolved path.
+	#[must_use]
+	pub fn permits_resolved_for_host(&self, resolved: &Path, access: FenceAccess) -> bool {
+		#[cfg(target_os = "macos")]
+		{
+			self.permits_resolved_on_seatbelt(resolved, access)
+		}
+		#[cfg(not(target_os = "macos"))]
+		{
+			self.permits_resolved(resolved, access)
+		}
+	}
+
+	/// Evaluate an already resolved path with the macOS Seatbelt-only denies included.
+	///
+	/// This is public so the pure policy can be exercised on non-macOS CI. Runtime shell callers use
+	/// [`Self::permits_resolved_for_host`] and therefore select it only on macOS.
+	#[must_use]
+	pub fn permits_resolved_on_seatbelt(&self, resolved: &Path, access: FenceAccess) -> bool {
+		self.permits_resolved_with_seatbelt_denies(resolved, access, true)
+	}
+
 	/// Whether an **already resolved** path may be accessed for `access`.
 	///
 	/// Separate from [`Self::permits`] so a caller that is about to open the path can resolve once,
@@ -224,11 +256,21 @@ impl ContainmentFence {
 	/// A boundary that holds 99% of the time is not a boundary.
 	#[must_use]
 	pub fn permits_resolved(&self, resolved: &Path, access: FenceAccess) -> bool {
+		self.permits_resolved_with_seatbelt_denies(resolved, access, false)
+	}
+
+	fn permits_resolved_with_seatbelt_denies(
+		&self,
+		resolved: &Path,
+		access: FenceAccess,
+		include_seatbelt_denies: bool,
+	) -> bool {
 		if self.allow.is_empty()
 			&& self.allow_read_only.is_empty()
 			&& self.allow_write_only.is_empty()
 			&& self.deny.is_empty()
 			&& self.deny_enumerate.is_empty()
+			&& (!include_seatbelt_denies || self.deny_on_seatbelt.is_empty())
 		{
 			return true;
 		}
@@ -244,7 +286,11 @@ impl ContainmentFence {
 			access
 		};
 
-		let denied = deepest_match(&self.deny, resolved);
+		let denied = deepest_match(&self.deny, resolved).max(if include_seatbelt_denies {
+			deepest_match(&self.deny_on_seatbelt, resolved)
+		} else {
+			None
+		});
 		let read_only = deepest_match(&self.allow_read_only, resolved);
 		let write_only = deepest_match(&self.allow_write_only, resolved);
 		let allowed = deepest_match(&self.allow, resolved);

--- a/crates/brush-core-vendored/src/expansion.rs
+++ b/crates/brush-core-vendored/src/expansion.rs
@@ -646,10 +646,10 @@ impl<'a> WordExpander<'a> {
 				.expand(
 					self.shell.working_dir(),
 					Some(&|path: &std::path::Path| {
-						fence.permits(path, crate::containment::FenceAccess::Read)
+						fence.permits_for_host(path, crate::containment::FenceAccess::Read)
 					}),
 					Some(&|path: &std::path::Path| {
-						fence.permits(path, crate::containment::FenceAccess::Enumerate)
+						fence.permits_for_host(path, crate::containment::FenceAccess::Enumerate)
 					}),
 					&options,
 				)

--- a/crates/brush-core-vendored/src/shell.rs
+++ b/crates/brush-core-vendored/src/shell.rs
@@ -1435,7 +1435,7 @@ impl Shell {
 		// paths again would just re-run the race.
 		if let Some(fence) = params.containment.as_ref() {
 			let resolved = crate::containment::canonicalize_for_fence(&path_to_open);
-			if !fence.permits_resolved(&resolved, access) {
+			if !fence.permits_resolved_for_host(&resolved, access) {
 				return Err(std::io::Error::new(
 					std::io::ErrorKind::PermissionDenied,
 					format!("{}: outside this session's boundary", path_to_open.display()),
@@ -1452,7 +1452,7 @@ impl Shell {
 			// directory-swap race still leaked 23 times in 600 attempts with only resolving and inode
 			// comparison in place.
 			let swapped = match crate::containment::path_of_handle(&opened) {
-				Some(reached) => !fence.permits_resolved(&reached, access),
+				Some(reached) => !fence.permits_resolved_for_host(&reached, access),
 				// Nothing to ask on this platform, so fall back to identity: a file that existed when
 				// it was cleared must still be that file, and one that did not can only have been
 				// created, so its directory had to be there and hold still. Weaker, and the reason the
@@ -1516,9 +1516,10 @@ impl Shell {
 			// — and every later relative path would resolve from there.
 			let destination =
 				crate::containment::canonicalize_for_fence(&self.absolute_path(target_dir.as_ref()));
-			let readable = fence.permits_resolved(&destination, crate::containment::FenceAccess::Read);
+			let readable =
+				fence.permits_resolved_for_host(&destination, crate::containment::FenceAccess::Read);
 			let writable =
-				fence.permits_resolved(&destination, crate::containment::FenceAccess::Write);
+				fence.permits_resolved_for_host(&destination, crate::containment::FenceAccess::Write);
 			if !readable || !writable {
 				return Err(error::ErrorKind::OutsideBoundary(destination).into());
 			}

--- a/crates/containment-check/tests/complement.rs
+++ b/crates/containment-check/tests/complement.rs
@@ -476,6 +476,41 @@ fn seatbelt_customer_container_deny_is_recursive_but_deeper_grants_win() {
 	);
 }
 
+#[test]
+fn seatbelt_in_process_checks_apply_customer_deny_and_deeper_grants() {
+	let parent = PathBuf::from("/Users/alice/customers");
+	let workspace = parent.join("example-a");
+	let sibling = parent.join("example-b");
+	let trusted = parent.join("shared-handoff");
+	let fence = ContainmentFence {
+		allow: vec![workspace.clone(), trusted.clone()],
+		deny_on_seatbelt: vec![parent],
+		..ContainmentFence::default()
+	};
+
+	assert!(
+		fence.permits_resolved(&sibling.join("planted.env"), FenceAccess::Write),
+		"the portable policy deliberately ignores the Seatbelt-only customer deny"
+	);
+	#[cfg(not(target_os = "macos"))]
+	assert!(
+		fence.permits_resolved_for_host(&sibling.join("planted.env"), FenceAccess::Write),
+		"non-macOS hosts must retain the portable policy"
+	);
+	assert!(
+		!fence.permits_resolved_on_seatbelt(&sibling.join("planted.env"), FenceAccess::Write),
+		"an in-process macOS redirection must enforce the same deny as sandbox-exec"
+	);
+	assert!(
+		fence.permits_resolved_on_seatbelt(&workspace.join("notes.md"), FenceAccess::Write),
+		"the deeper workspace grant must win"
+	);
+	assert!(
+		fence.permits_resolved_on_seatbelt(&trusted.join("output.txt"), FenceAccess::Write),
+		"an explicit deeper trusted grant must win"
+	);
+}
+
 /// Two lists naming the same path must resolve the way `permits_resolved` does:
 /// deny wins.
 #[test]


### PR DESCRIPTION
Closes #3477

## Summary

- apply the macOS-only sibling-customer deny to filesystem work performed inside Brush itself
- use the host-aware policy for redirections, shell directory changes, and glob expansion
- preserve portable Linux/Windows semantics and deeper workspace or explicit trusted grants

## TDD and validation

- red: `cargo test -p containment-check seatbelt_in_process_checks_apply_customer_deny_and_deeper_grants` failed because the host-aware Seatbelt policy did not exist
- green: `cargo test -p containment-check` — 19 passed
- focused TypeScript containment suites — 80 passed
- `bun run check` — passed
- `bun run lint` — passed (two existing non-fatal Biome warnings in `install-smoke-workspace.test.ts`)
- `bun run test` — 7,789 tests passed across the other workspaces; xcsh had 6,771 passed and two unrelated governed-workflow assertions failed, already owned by #3478 in its separate active worktree
- changed-scope PII enforcement — clean
- AGY reviewer and verifier — approve, zero findings

The macOS CI `Seatbelt sibling-customer enforcement` step is the platform acceptance test for the redirection that failed in run 33192358396.
