### PR TITLE
test(ci): align validation with governed caller

### DIFF
--- a/packages/coding-agent/test/scripts/arc-runner-workflow-contract.test.ts
+++ b/packages/coding-agent/test/scripts/arc-runner-workflow-contract.test.ts
@@ -166,7 +166,11 @@ test("repository-specific managed callers use the socketless ARC route", async (
 	for (const [workflowName, jobIds] of Object.entries(expectedJobs)) {
 		const document = parse(await Bun.file(path.join(WORKFLOW_ROOT, workflowName)).text()) as WorkflowDocument;
 		for (const jobId of jobIds) {
-			expect(document.jobs?.[jobId]?.["runs-on"], `${workflowName}:${jobId}`).toBe("xcsh-socketless");
+			const expectedRoute =
+				workflowName === "super-linter.yml"
+					? `\${{ github.repository == 'f5-sales-demo/xcsh' && 'xcsh-socketless' || 'managed-socketless' }}`
+					: "xcsh-socketless";
+			expect(document.jobs?.[jobId]?.["runs-on"], `${workflowName}:${jobId}`).toBe(expectedRoute);
 		}
 	}
 });

--- a/packages/coding-agent/test/scripts/super-linter-workflow.test.ts
+++ b/packages/coding-agent/test/scripts/super-linter-workflow.test.ts
@@ -14,7 +14,7 @@ describe("Super-Linter workflow", () => {
 		const source = await Bun.file(SUPER_LINTER_WORKFLOW).text();
 
 		expect(hasImmutableGovernedSuperLinter(source)).toBe(true);
-		expect(source).toContain('rust_edition: "2024"');
+		expect(source).toContain(`rust_edition: \${{ github.repository == 'f5-sales-demo/xcsh' && '2024' || '2021' }}`);
 	});
 
 	it("accepts pin rolls while rejecting mutable or noncanonical references", () => {

--- a/scripts/tdd-docker.sh
+++ b/scripts/tdd-docker.sh
@@ -108,9 +108,10 @@ assert_job_route .github/workflows/arc-compatibility.yml container xcsh-containe
 assert_job_route .github/workflows/auto-merge.yml require-token xcsh-socketless
 assert_job_route .github/workflows/dependabot-auto-merge.yml auto-merge xcsh-socketless
 assert_job_route .github/workflows/semgrep.yml semgrep xcsh-socketless
-assert_job_route .github/workflows/super-linter.yml linked-issue xcsh-socketless
-grep -Fq 'socketless_runner_label: xcsh-socketless' .github/workflows/super-linter.yml
-grep -Fq 'container_build_runner_label: xcsh-container-build' .github/workflows/super-linter.yml
+grep -Fq '  linked-issue:' .github/workflows/super-linter.yml
+grep -Fq "runs-on: \${{ github.repository == 'f5-sales-demo/xcsh' && 'xcsh-socketless' || 'managed-socketless' }}" .github/workflows/super-linter.yml
+grep -Fq "socketless_runner_label: \${{ github.repository == 'f5-sales-demo/xcsh' && 'xcsh-socketless' || 'managed-socketless' }}" .github/workflows/super-linter.yml
+grep -Fq "container_build_runner_label: \${{ github.repository == 'f5-sales-demo/xcsh' && 'xcsh-container-build' || 'managed-container-build' }}" .github/workflows/super-linter.yml
 assert_job_route .github/workflows/translation-audit.yml audit xcsh-socketless
 assert_job_route .github/workflows/workflow-security-audit.yml audit xcsh-socketless
 


### PR DESCRIPTION
## Summary

- align xcsh validation with the repository-conditioned Super-Linter runner and Rust edition expressions emitted by governance
- keep the canonical linked-issue job id and assert it explicitly
- restore the Alpine container contract without editing the protected workflow

## Validation

- focused workflow tests: 8 passed
- `bash scripts/tdd-docker.sh`: passed
- `bun run check`: passed
- `bun run lint`: passed
- PII gate: clean
- AGY reviewer and verifier: approved with zero findings

Closes #3478