### PR TITLE
test(plugin): avoid binary magic path collision

### DIFF
--- a/packages/coding-agent/test/internal-urls/plugin-resolve.test.ts
+++ b/packages/coding-agent/test/internal-urls/plugin-resolve.test.ts
@@ -14,7 +14,7 @@ function u(input: string): InternalUrl {
 }
 
 beforeAll(async () => {
-	root = await fs.mkdtemp(path.join(os.tmpdir(), "plugin-resolve-"));
+	root = await fs.mkdtemp(path.join(os.tmpdir(), "plugin-resolve-PK-"));
 	await fs.mkdir(path.join(root, ".xcsh-plugin"), { recursive: true });
 	await fs.mkdir(path.join(root, "schema"), { recursive: true });
 	await fs.mkdir(path.join(root, "engine"), { recursive: true });
@@ -119,7 +119,7 @@ describe("binary resources", () => {
 	test("the raw bytes never appear in the content", async () => {
 		const r = await resolver().resolve(u("xcsh://plugin/demo/template"));
 		// A UTF-8 read of this file yields "PK\u0003\u0004\u0000\ufffd\ufffd".
-		expect(r.content).not.toContain("PK");
+		expect(r.content.startsWith("PK")).toBe(false);
 		expect(r.content).not.toContain("\u0000");
 	});
 


### PR DESCRIPTION
## Summary

- make the binary-resource fixture deterministically include `PK` in its temporary path
- test the raw ZIP magic only at the start of returned content, avoiding false positives from JSON metadata paths

## Validation

- focused plugin resolver tests: 14 passed
- `bun run check`: passed
- `bun run lint`: passed
- PII gate: clean
- AGY reviewer and verifier: approved with zero findings

Closes #3479