### PR TITLE
test(windows): verify multi-volume containment

### DIFF
--- a/.github/workflows/windows-containment-uat.yml
+++ b/.github/workflows/windows-containment-uat.yml
@@ -1,0 +1,51 @@
+---
+name: Windows Multi-Volume Containment UAT
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/windows-containment-uat.yml"
+      - "packages/coding-agent/src/sandbox/containment.ts"
+      - "packages/coding-agent/src/prompts/internal-urls/containment.md"
+      - "packages/coding-agent/test/windows-drive-containment.uat.test.ts"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-containment-uat-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  native-two-volume:
+    name: Native Windows two-volume containment
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Inventory native Windows volumes
+        shell: pwsh
+        run: |
+          Get-Volume |
+            Sort-Object DriveLetter |
+            Select-Object DriveLetter, DriveType, HealthStatus, OperationalStatus, Size |
+            Format-Table -AutoSize
+
+      - name: Set up Bun 1.3
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          no-cache: true
+          bun-version: "1.3"
+
+      - name: Install workspace dependencies
+        shell: bash
+        run: bun install --frozen-lockfile
+
+      - name: Run native multi-volume UAT
+        shell: bash
+        run: bun test packages/coding-agent/test/windows-drive-containment.uat.test.ts

--- a/packages/coding-agent/src/prompts/internal-urls/containment.md
+++ b/packages/coding-agent/src/prompts/internal-urls/containment.md
@@ -61,6 +61,10 @@ Without a runtime backend, Bash child-process reads cannot enforce protected-con
 xcsh-private-root denial. Structured tools still enforce those rules, and ordinary work remains
 unrestricted. The persistent `python` kernel is likewise unfenced beyond its explicit `cwd` check.
 
+On Windows, mounted drive letters other than the workspace drive lose root enumeration in structured
+tools. A UNC share that is not mapped to a drive letter cannot be enumerated and is outside this
+courtesy boundary; map it to a drive or grant a known path explicitly when it belongs to the task.
+
 Treat the boundary as a statement of intent rather than a guarantee, and do not go looking for paths
 outside the session directory on the assumption that something would stop you.
 {{/if}}

--- a/packages/coding-agent/src/sandbox/containment.ts
+++ b/packages/coding-agent/src/sandbox/containment.ts
@@ -531,8 +531,16 @@ export function buildContainmentFence(options: ContainmentOptions): ContainmentF
 		if (resolved === fsRoot) continue; // never the root the workspace lives on
 		// A directory containing home is normally too broad to protect because it would hide unrelated
 		// operational entries. Account containers are the deliberate exception: their listing is the
-		// discovery surface, while every named account remains reachable (#2788, #2931).
-		if (home !== undefined && pathIsWithin(resolved, home) && !accountRoots.has(resolved)) continue;
+		// discovery surface, while every named account remains reachable (#2788, #2931). A separate
+		// Windows drive is also an exception: only its exact listing is hidden, so home and every named
+		// descendant retain their normal access.
+		if (
+			!rootScoped.has(resolved) &&
+			home !== undefined &&
+			pathIsWithin(resolved, home) &&
+			!accountRoots.has(resolved)
+		)
+			continue;
 		// The session workspace and explicit read/full grants retain enumeration. A write-only grant does
 		// not imply permission to learn directory entries.
 		if (resolved === workspace) continue;

--- a/packages/coding-agent/src/sandbox/containment.ts
+++ b/packages/coding-agent/src/sandbox/containment.ts
@@ -352,12 +352,11 @@ function resolveGrants(roots: readonly string[] | undefined, home: string): Set<
  * kernel backend, so this exact-enumeration rule is enforced for structured tools but cannot confine a
  * Bash child process.
  *
- * **Unverified on Windows.** The probe below cannot run on the platforms this fleet uses, so what is
- * tested is the exact-enumeration protection, not discovery — see the test, which injects the list.
+ * Native Windows UAT exercises this production probe against a real second mounted volume.
  *
  * UNC paths (`\\server\share`) have no enumerable root and are not covered.
  */
-function otherFilesystemRoots(fsRoot: string): string[] {
+export function otherFilesystemRoots(fsRoot: string): string[] {
 	if (process.platform !== "win32") return [];
 	const roots: string[] = [];
 	for (let letter = "A".charCodeAt(0); letter <= "Z".charCodeAt(0); letter++) {

--- a/packages/coding-agent/test/sandbox-containment.test.ts
+++ b/packages/coding-agent/test/sandbox-containment.test.ts
@@ -535,6 +535,21 @@ describe("buildContainmentFence — adversarial review of #2624", () => {
 		expect(fence.denyEnumerate).toContain(otherRoot);
 	});
 
+	it("protects another filesystem root even when that root contains home", () => {
+		const workspaceContainer = realTmp("workspace-drive");
+		const workspace = path.join(workspaceContainer, "repo");
+		const otherRoot = realTmp("home-drive");
+		const home = path.join(otherRoot, "Users", "operator");
+		fs.mkdirSync(workspace, { recursive: true });
+		fs.mkdirSync(home, { recursive: true });
+
+		const fence = buildContainmentFence({ workspace, home, fsRoot: workspaceContainer, otherRoots: [otherRoot] });
+
+		expect(fence.denyEnumerate).toContain(otherRoot);
+		expect(fenceVerdict(fence, otherRoot, "enumerate")).toBe("deny");
+		expect(fenceVerdict(fence, path.join(home, "known.txt"), "read")).toBe("allow");
+	});
+
 	// …but the root the workspace actually lives on is never denied, however it arrives.
 	it("never denies the workspace's own filesystem root", () => {
 		const container = realTmp("ownroot");

--- a/packages/coding-agent/test/windows-drive-containment.uat.test.ts
+++ b/packages/coding-agent/test/windows-drive-containment.uat.test.ts
@@ -41,9 +41,7 @@ describe.skipIf(process.platform !== "win32")("native Windows multi-volume conta
 		const otherRoot = otherRoots[0];
 		const fence = buildContainmentFence({ workspace, home: os.homedir() });
 		const otherCanonical = canonical(otherRoot);
-		expect(fence.denyEnumerate.map(canonical).map(root => root.toLowerCase())).toContain(
-			otherCanonical.toLowerCase(),
-		);
+		expect(fence.denyEnumerate.map(root => root.toLowerCase())).toContain(otherCanonical.toLowerCase());
 		expect(fenceVerdict(fence, otherCanonical, "enumerate")).toBe("deny");
 		expect(fenceVerdict(fence, workspaceRoot, "enumerate")).toBe("allow");
 

--- a/packages/coding-agent/test/windows-drive-containment.uat.test.ts
+++ b/packages/coding-agent/test/windows-drive-containment.uat.test.ts
@@ -1,0 +1,145 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { buildContainmentFence, fenceVerdict, otherFilesystemRoots } from "../src/sandbox/containment";
+import { evaluateToolCall } from "../src/sandbox/enforce";
+
+const fixtures: string[] = [];
+
+afterAll(() => {
+	for (const fixture of fixtures) fs.rmSync(fixture, { recursive: true, force: true });
+});
+
+function canonical(value: string): string {
+	return fs.realpathSync(value);
+}
+
+describe.skipIf(process.platform !== "win32")("native Windows multi-volume containment UAT", () => {
+	it("discovers a real second volume and applies the discovery-only contract", () => {
+		const workspace = canonical(process.cwd());
+		const workspaceRoot = path.parse(workspace).root;
+		const startedAt = performance.now();
+		const otherRoots = otherFilesystemRoots(workspaceRoot);
+		const elapsedMs = performance.now() - startedAt;
+
+		console.info(
+			JSON.stringify({
+				workspaceRoot,
+				otherRoots,
+				discoveryElapsedMs: Math.round(elapsedMs),
+			}),
+		);
+
+		expect(otherRoots.length).toBeGreaterThan(0);
+		expect(elapsedMs).toBeLessThan(5_000);
+		for (const root of otherRoots) {
+			expect(fs.statSync(root).isDirectory()).toBe(true);
+			expect(root.toLowerCase()).not.toBe(workspaceRoot.toLowerCase());
+		}
+
+		const otherRoot = otherRoots[0];
+		const fence = buildContainmentFence({ workspace, home: os.homedir() });
+		const otherCanonical = canonical(otherRoot);
+		expect(fence.denyEnumerate.map(canonical).map(root => root.toLowerCase())).toContain(
+			otherCanonical.toLowerCase(),
+		);
+		expect(fenceVerdict(fence, otherCanonical, "enumerate")).toBe("deny");
+		expect(fenceVerdict(fence, workspaceRoot, "enumerate")).toBe("allow");
+
+		const structuredRead = evaluateToolCall({
+			toolName: "read",
+			input: { file_path: otherRoot },
+			cwd: workspace,
+			fence,
+		});
+		const structuredSearch = evaluateToolCall({
+			toolName: "grep",
+			input: { pattern: "probe", path: otherRoot },
+			cwd: workspace,
+			fence,
+		});
+		expect(structuredRead.block).toBe(true);
+		expect(structuredRead.reason).toContain("enumerate boundary");
+		expect(structuredSearch.block).toBe(true);
+
+		// #2931 deliberately treats arbitrary Bash/Python source as data. Windows has no runtime
+		// backend, so these are statements of intent, not a claim of hard confinement.
+		expect(
+			evaluateToolCall({
+				toolName: "bash",
+				input: { command: `ls ${JSON.stringify(otherRoot)}` },
+				cwd: workspace,
+				fence,
+			}).block,
+		).toBe(false);
+		expect(
+			evaluateToolCall({
+				toolName: "python",
+				input: { code: `import os; os.listdir(${JSON.stringify(otherRoot)})` },
+				cwd: workspace,
+				fence,
+			}).block,
+		).toBe(false);
+	});
+
+	it("restores second-volume enumeration and named I/O with an explicit read-write grant", () => {
+		const workspace = canonical(process.cwd());
+		const workspaceRoot = path.parse(workspace).root;
+		const otherRoots = otherFilesystemRoots(workspaceRoot);
+		expect(otherRoots.length).toBeGreaterThan(0);
+
+		let fixture: string | undefined;
+		let otherRoot: string | undefined;
+		const candidateBases = [os.homedir(), os.tmpdir(), process.env.RUNNER_TEMP, ...otherRoots].filter(
+			(value): value is string => value !== undefined,
+		);
+		for (const root of otherRoots) {
+			for (const base of candidateBases) {
+				if (path.parse(base).root.toLowerCase() !== root.toLowerCase()) continue;
+				try {
+					fixture = fs.mkdtempSync(path.join(base, "xcsh-windows-drive-uat-"));
+					otherRoot = root;
+					fixtures.push(fixture);
+					break;
+				} catch {
+					// Try the next known writable location on the same real volume.
+				}
+			}
+			if (fixture !== undefined) break;
+		}
+		expect(fixture).toBeDefined();
+		expect(otherRoot).toBeDefined();
+		if (fixture === undefined || otherRoot === undefined) throw new Error("no writable secondary volume");
+
+		const knownFile = path.join(fixture, "known.txt");
+		fs.writeFileSync(knownFile, "known\n");
+		const defaultFence = buildContainmentFence({ workspace, home: os.homedir() });
+		expect(fenceVerdict(defaultFence, knownFile, "read")).toBe("allow");
+		expect(fenceVerdict(defaultFence, knownFile, "write")).toBe("allow");
+
+		const grantedFence = buildContainmentFence({
+			workspace,
+			home: os.homedir(),
+			readOnlyRoots: [otherRoot],
+			writeOnlyRoots: [otherRoot],
+		});
+		expect(fenceVerdict(grantedFence, canonical(otherRoot), "enumerate")).toBe("allow");
+		expect(
+			evaluateToolCall({
+				toolName: "read",
+				input: { file_path: otherRoot },
+				cwd: workspace,
+				fence: grantedFence,
+			}).block,
+		).toBe(false);
+		expect(
+			evaluateToolCall({
+				toolName: "write",
+				input: { file_path: knownFile },
+				cwd: workspace,
+				fence: grantedFence,
+			}).block,
+		).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

- exercise the production Windows A:–Z: volume probe on a native hosted runner
- verify a real second volume is hidden from structured enumeration while the workspace volume remains usable
- verify an explicit read/write grant reopens second-volume enumeration and named I/O
- bound absent or empty drive-letter probing to five seconds
- document the UNC limitation and preserve the post-#2931 Bash/Python source-as-data contract

## Validation

- `bun run check`
- `bun run lint`
- full workspace test suite (7,334 tests, zero failures)
- focused containment suite after final rebase/fix: 127 passed, 2 native-Windows skips
- governed workflow-security validator: passed
- governed runner-route audit: 28 routes passed
- `actionlint .github/workflows/windows-containment-uat.yml`
- changed-scope PII enforcement: clean
- AGY reviewer and verifier: approved, no findings (receipt `0497f03145b431924ae178e598bb04db1a0fd58a28b203ee9e538c0aa1356f28`)

The issue's acceptance reconciliation comment supersedes its pre-#2931 blanket Bash/Python path-scanning wording; Windows remains scanner-only and this UAT verifies the current discovery boundary.

Closes #2629
